### PR TITLE
Update Vue Router to use history mode.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import Scoreboard from '@/views/Scoreboard.vue';
 import Statistics from '@/views/Statistics.vue';
 
 const router = new VueRouter({
+  mode: 'history',
   routes: [
     {
       name: 'login',


### PR DESCRIPTION
Use history mode when instantiating the VueRouter object so
that the different views use paths like "/stats" instead of
ugly fragments like "/#/stats". History mode uses the HTML5
History API to manipulate URLs.

Firebase Hosting is already configured to rewrite all paths
to /index.html to handle users loading alternate paths
directly.