### PR TITLE
Lazily render menus in ClimbDropdown.

### DIFF
--- a/src/components/ClimbDropdown.vue
+++ b/src/components/ClimbDropdown.vue
@@ -3,23 +3,25 @@
      found in the LICENSE file. -->
 
 <template>
-  <v-menu class="mr-3">
+  <v-menu class="mr-3" lazy>
     <template v-slot:activator="{ on }">
       <v-btn
-        :color="states[currentState].color"
+        :color="stateColors[currentState]"
         class="white--text narrow-button"
         v-on="on"
       >
-        {{ states[currentState].abbrev }}
+        {{ stateAbbrevs[currentState] }}
       </v-btn>
     </template>
     <v-list>
-      <v-list-tile
-        v-for="state in orderedStates"
-        :key="state"
-        @click="setState(state)"
-      >
-        <v-list-tile-title>{{ states[state].name }}</v-list-tile-title>
+      <v-list-tile @click="setState(ClimbState.LEAD)">
+        <v-list-tile-title>Lead</v-list-tile-title>
+      </v-list-tile>
+      <v-list-tile @click="setState(ClimbState.TOP_ROPE)">
+        <v-list-tile-title>Top-rope</v-list-tile-title>
+      </v-list-tile>
+      <v-list-tile @click="setState(ClimbState.NOT_CLIMBED)">
+        <v-list-tile-title>Not climbed</v-list-tile-title>
       </v-list-tile>
     </v-list>
   </v-menu>
@@ -28,33 +30,26 @@
 <script>
 import firebase from 'firebase/app';
 import { auth, db } from '@/firebase';
-import ClimbState from './ClimbState.js'
+import ClimbState from '@/components/ClimbState.js'
+
+const stateColors = Object.freeze({
+  [ClimbState.LEAD]: 'red',
+  [ClimbState.TOP_ROPE]: 'red darken-4',
+  [ClimbState.NOT_CLIMBED]: 'gray',
+});
+
+const stateAbbrevs = Object.freeze({
+  [ClimbState.LEAD]: 'L',
+  [ClimbState.TOP_ROPE]: 'TR',
+  [ClimbState.NOT_CLIMBED]: '',
+});
 
 export default {
   props: ['currentState', 'routeID'],
   data: () => ({
-    states: [
-      {
-        name: 'Not climbed',
-        abbrev: '',
-        color: 'gray'
-      },
-      {
-        name: 'Lead',
-        abbrev: 'L',
-        color: 'red darken-4'
-      },
-      {
-        name: 'Top-rope',
-        abbrev: 'TR',
-        color: 'red'
-      }
-    ],
-    orderedStates: [
-      ClimbState.LEAD,
-      ClimbState.TOP_ROPE,
-      ClimbState.NOT_CLIMBED
-    ],
+    ClimbState: ClimbState,
+    stateColors: stateColors,
+    stateAbbrevs: stateAbbrevs,
   }),
   methods: {
     setState(state) {

--- a/src/components/RouteList.vue
+++ b/src/components/RouteList.vue
@@ -10,7 +10,7 @@
     >
       <v-list-tile-action>
         <ClimbDropdown
-          v-bind:currentState="climbs[route.id] || 0"
+          v-bind:currentState="climbs[route.id] || ClimbState.NOT_CLIMBED"
           v-bind:routeID="route.id"
         />
       </v-list-tile-action>
@@ -33,12 +33,16 @@
 
 <script>
 import ClimbDropdown from '@/components/ClimbDropdown.vue'
+import ClimbState from '@/components/ClimbState.js'
 
 export default {
   components: {
     ClimbDropdown,
   },
   props: ['climbs', 'routes'],
+  data: () => ({
+    ClimbState: ClimbState,
+  }),
 }
 </script>
 

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -3,12 +3,21 @@
      found in the LICENSE file. -->
 
 <template>
-  <v-expansion-panel v-if="loaded" :expand="true">
-    <v-expansion-panel-content v-for="area in sortedData.areas" :key="area.name">
+  <v-expansion-panel
+    v-if="loaded"
+    expand
+  >
+    <v-expansion-panel-content
+      v-for="area in sortedData.areas"
+      :key="area.name"
+    >
       <template v-slot:header>
         <div>{{area.name}}</div>
       </template>
-      <RouteList v-bind:climbs="userDoc.climbs || {}" v-bind:routes="area.routes" />
+      <RouteList
+        v-bind:climbs="userDoc.climbs || {}"
+        v-bind:routes="area.routes"
+      />
     </v-expansion-panel-content>
   </v-expansion-panel>
   <v-container v-else fill-height>


### PR DESCRIPTION
Add the 'lazy' attribute to <v-menu> in the ClimbDropdown
component. This reduces initial RouteList render time from
7.5-8s to 4.5-5s when displaying four ClimbDropdowns per
route on my laptop.

Also use frozen objects to store constant information about
states so that Vue doesn't need to watch for changes.