### PR TITLE
Lazily load login view.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,9 +4,7 @@
       "target": "prod",
       "public": "dist",
       "ignore": [
-        "firebase.json",
-        "**/.*",
-        "**/node_modules/**"
+        "report.html"
       ],
       "rewrites": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11874,6 +11874,15 @@
       "integrity": "sha512-TigfiZUs7SN3Z6uxKilqJUtYxte8vp0F4QxabCli6hkKPqU97JzAZc3P7AL6omkRAd2DMI26fOrIGjuALTvXww==",
       "dev": true
     },
+    "vue-cli-plugin-webpack-bundle-analyzer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-webpack-bundle-analyzer/-/vue-cli-plugin-webpack-bundle-analyzer-1.4.0.tgz",
+      "integrity": "sha512-x7NIDe17IewKc/RaIkM2JBVGJLIKqlscxYKFJ130++yncU6zelAnwIVAKZI9cmtTi3nDJENB44H1BLi4CeU84A==",
+      "dev": true,
+      "requires": {
+        "webpack-bundle-analyzer": "^3.3.2"
+      }
+    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "vue-cli-plugin-vuetify": "^0.5.0",
+    "vue-cli-plugin-webpack-bundle-analyzer": "^1.4.0",
     "vue-template-compiler": "^2.6.10",
     "vuetify-loader": "^1.0.5"
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,7 +9,10 @@ import VueRouter from 'vue-router';
 
 import { auth } from '@/firebase';
 
-import Login from '@/views/Login.vue';
+// Lazily load the Login view since it imports firebaseui, which is 200+ KB.
+// See https://alexjover.com/blog/lazy-load-in-vue-using-webpack-s-code-splitting/
+const Login = () => import('@/views/Login.vue');
+
 import Profile from '@/views/Profile.vue';
 import Routes from '@/views/Routes.vue';
 import Scoreboard from '@/views/Scoreboard.vue';

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   devServer: {
     disableHostCheck: true
+  },
+  pluginOptions: {
+    webpackBundleAnalyzer: {
+      openAnalyzer: false
+    }
   }
 }


### PR DESCRIPTION
Make vue-router only load the Login view when it's needed.
This reduces the chunk-vendors size by 200+ KB, since it
lets us lazily import firebaseui.

Unfortunately, the firebase package itself is still huge
(592 KB minified, 154 KB gzipped), and we need it in order
to do much of anything.

Also add vue-cli-plugin-webpack-bundle-analyzer, which
generates a report.html file in the dist directory showing
the sizes of different modules.

Update firebase.json to exclude report.html and remove some
default excludes that don't make sense to me (since they're
referencing things that aren't in the dist dir).