### PR TITLE
Increase font size for area names in Routes view.

### DIFF
--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -12,7 +12,7 @@
       :key="area.name"
     >
       <template v-slot:header>
-        <div>{{area.name}}</div>
+        <div class="area">{{area.name}}</div>
       </template>
       <RouteList
         v-bind:climbs="userDoc.climbs || {}"
@@ -49,3 +49,9 @@ export default {
   },
 }
 </script>
+
+<style>
+.area {
+  font-size: 16px;
+}
+</style>


### PR DESCRIPTION
The area headings in the Routes view were just using the
default (small) font size. Set them to 16px to match the
size used for route names.