### PR TITLE
Explicitly reset doc snapshots when unbinding.

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -513,7 +513,10 @@ export default {
           () => {
             // Update the UI to reflect the change.
             // TODO: Just watch userDoc.team instead?
-            this.$unbind('teamDoc', { reset: () => ({}) });
+            this.$unbind('teamDoc');
+            // $unbind's 'reset' attribute doesn't seem to work correctly.
+            // Often this.teamDoc ends up being null instead of an empty object.
+            this.teamDoc = {};
             this.teamRef = null;
             this.leaveDialogShown = false;
           },

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -101,7 +101,8 @@ export default {
         this.teamRef = db.collection('teams').doc(this.userDoc.team);
         this.$bind('teamDoc', this.teamRef);
       } else {
-        this.$unbind('teamDoc', { reset: () => ({}) });
+        this.$unbind('teamDoc');
+        this.teamDoc = {};
         this.teamRef = null;
       }
     },


### PR DESCRIPTION
Explicitly reset Firebase snapshot properties to empty
objects when unbinding them in the Profile and Routes views.
vue-firebase seems to (sometimes?) set them to null even
when asked to do otherwise.