### PR TITLE
Use competition name as page title.

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,35 +2,43 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    // TODO: Add function for auth check.
+    // Returns true if the user is logged in.
+    function loggedIn() {
+      return request.auth != null && request.auth.uid != null;
+    }
 
-    // Let logged-in users read all global docs besides "auth".
+    // Let anyone get /global/config (which provides the competition name,
+    // which is needed for the page title).
+    match /global/config {
+      allow get: if true;
+    }
+
+    // Let logged-in users read all other global docs besides "auth".
     match /global/{doc} {
-      allow get:
-        if request.auth.uid != null && doc != "auth";
+      allow get: if loggedIn() && doc != "auth";
     }
 
     // Give users full access to their own docs.
     // TODO: Validate fields here.
     match /users/{uid} {
-      allow get, write: if request.auth.uid == uid;
+      allow get, write: if loggedIn() && request.auth.uid == uid;
     }
 
     match /teams/{tid} {
       // Let all logged-in users create new teams.
-      allow create: if request.auth.uid != null;
+      allow create: if loggedIn();
 
       // Let team members access their team, and let all logged-in
       // users access update incomplete teams (to add themselves).
       allow get, update:
-        if request.auth.uid != null &&
+        if loggedIn() &&
             (request.auth.uid in resource.data.users ||
              resource.data.users.size() < 2);
     }
 
     match /invites/{iid} {
       // Let all logged-in users create or read invites.
-      allow create, get: if request.auth.uid != null;
+      allow create, get: if loggedIn();
     }
 
     // Access to everything else is denied by default.

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
-    <title>ascenso</title>
+    <title>Loading...</title>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -68,7 +68,7 @@ export default {
     };
   },
   firestore: {
-    config: db.collection('global').doc('config'),
+    config: db.doc('global/config'),
   },
 };
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import VueRouter from 'vue-router';
 import './plugins/vuetify';
 import { firestorePlugin } from 'vuefire';
 
-import { auth } from './firebase';
+import { auth, db } from './firebase';
 
 import App from './App.vue';
 import router from './router';
@@ -33,3 +33,10 @@ auth.onAuthStateChanged(() => {
     }).$mount('#app');
   }
 });
+
+// Set the page title.
+db.doc('global/config')
+  .get()
+  .then(snap => {
+    document.title = snap.data().competitionName;
+  });


### PR DESCRIPTION
Make the page use the competition name as its title.
"Loading..." is used as the initial title.

Also permit unauthenticated access to the global/config
document, and add a loggedIn() function to firestore.rules
to reduce repetition and avoid (harmless?) null dereferences
of request.auth.