### PR TITLE
- use both user and team climb data to populate stats page

### DIFF
--- a/src/users/index.js
+++ b/src/users/index.js
@@ -14,7 +14,7 @@ export function bindUserAndTeamDocs(view, userId, userProp, teamProp) {
       () => {
         const team = view[userProp].team;
         if (!team) {
-          resolve({ user: userRef });
+          resolve({ user: userRef, team: null });
         }
         const teamRef = db.collection('teams').doc(team);
         view.$bind(teamProp, teamRef).then(() => {

--- a/src/users/index.js
+++ b/src/users/index.js
@@ -1,0 +1,20 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import { db } from '@/firebase';
+
+// Returns a promise that is satisfied once document snapshot(s) are loaded.
+export function bindUserAndTeamDocs(view, userId, userProp, teamProp) {
+  view.userRef = db.collection('users').doc(userId);
+  view.$bind(userProp, view.userRef).then(() => {
+    if (!view.userDoc.team) {
+      view.ready = true;
+    } else {
+      view.teamRef = db.collection('teams').doc(view.userDoc.team);
+      view.$bind(teamProp, view.teamRef).then(() => {
+        view.ready = true;
+      });
+    }
+  });
+}

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -532,9 +532,7 @@ export default {
     bindUserAndTeamDocs(this, auth.currentUser.uid, 'userDoc', 'teamDoc')
       .then(result => {
         this.userRef = result.user;
-        if (result.team) {
-          this.teamRef = result.team;
-        }
+        this.teamRef = result.team;
         this.ready = true;
       }, err => {
         console.log('Failed to bind user and team from database:', err);

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -529,7 +529,16 @@ export default {
   },
 
   mounted() {
-    bindUserAndTeamDocs(this, auth.currentUser.uid, 'userDoc', 'teamDoc');
+    bindUserAndTeamDocs(this, auth.currentUser.uid, 'userDoc', 'teamDoc')
+      .then(result => {
+        this.userRef = result.user;
+        if (result.team) {
+          this.teamRef = result.team;
+        }
+        this.ready = true;
+      }, err => {
+        console.log('Failed to bind user and team from database:', err);
+      });
   },
 };
 </script>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -239,6 +239,7 @@
 import firebase from 'firebase/app';
 import { auth, db } from '@/firebase';
 import Spinner from '@/components/Spinner.vue';
+import { bindUserAndTeamDocs } from '@/users';
 
 export default {
   components: {
@@ -528,17 +529,7 @@ export default {
   },
 
   mounted() {
-    this.userRef = db.collection('users').doc(auth.currentUser.uid);
-    this.$bind('userDoc', this.userRef).then(() => {
-      if (!this.userDoc.team) {
-        this.ready = true;
-      } else {
-        this.teamRef = db.collection('teams').doc(this.userDoc.team);
-        this.$bind('teamDoc', this.teamRef).then(() => {
-          this.ready = true;
-        });
-      }
-    });
+    bindUserAndTeamDocs(this, auth.currentUser.uid, 'userDoc', 'teamDoc');
   },
 };
 </script>

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -111,14 +111,11 @@ export default {
         const userId = auth.currentUser.uid;
         const userClimbs = Object.keys(users).map(uid => users[uid].climbs);
 
-        // Compute the stats for the user.
         this.itemsUser = this.computeStats(
           users[userId].climbs ? [users[userId].climbs] : []);
 
-        // Compute the stats for the whole team.
         this.itemsTeam = this.computeStats(userClimbs);
       } else if (this.userDoc.climbs) {
-        // Compute the stats for the user.
         this.itemsUser = this.computeStats([this.userDoc.climbs]);
       }
 


### PR DESCRIPTION
- separate the loading of user and team climbs from database into a
  helper function

TESTED:went to stats page when not on a team, when on a team of 1, and
when on a team of 2, added and removed climbs