### PR TITLE
Change first climber's color to red.

### DIFF
--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -29,7 +29,7 @@ import RouteList from '@/components/RouteList.vue';
 import Spinner from '@/components/Spinner.vue';
 
 // Colors associated with climbers.
-const climbColors = Object.freeze(['orange', 'indigo']);
+const climbColors = Object.freeze(['red', 'indigo']);
 
 export default {
   name: 'Routes',


### PR DESCRIPTION
Change the first climber's color from orange to red. The
lighter shade of orange was a bit too light, and red and
indigo should still be distinguishable with the three most
common types of color-blindness, per a page I looked at.