### PR TITLE
Disallow unused variables.

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { auth, db } from '@/firebase';
 import { Config } from '@/models';
 

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -241,7 +241,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import firebase from 'firebase/app';
 type DocumentReference = firebase.firestore.DocumentReference;
 
-import { auth, db, getUser, bindUserAndTeamDocs } from '@/firebase';
+import { db, getUser, bindUserAndTeamDocs } from '@/firebase';
 import { ClimbState, User, Team } from '@/models';
 import Spinner from '@/components/Spinner.vue';
 

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -27,7 +27,7 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import firebase from 'firebase/app';
 type DocumentReference = firebase.firestore.DocumentReference;
 
-import { auth, db, getUser } from '@/firebase';
+import { db, getUser } from '@/firebase';
 import {
   ClimberInfo,
   ClimbState,

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -22,7 +22,7 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import firebase from 'firebase/app';
 type DocumentReference = firebase.firestore.DocumentReference;
 
-import { auth, db, getUser, bindUserAndTeamDocs } from '@/firebase';
+import { db, getUser, bindUserAndTeamDocs } from '@/firebase';
 import { ClimbState, Statistic, IndexedData, User, Team } from '@/models';
 import Spinner from '@/components/Spinner.vue';
 import StatisticsList from '@/components/StatisticsList.vue';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,23 +9,14 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "noUnusedLocals": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "types": [
-      "vuetify",
-      "webpack-env"
-    ],
+    "types": ["vuetify", "webpack-env"],
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     },
-    "lib": [
-      "esnext",
-      "dom",
-      "dom.iterable",
-      "scripthost"
-    ]
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
   "include": [
     "src/**/*.ts",
@@ -34,7 +25,5 @@
     "tests/**/*.ts",
     "tests/**/*.tsx"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Set the noUnusedLocals option in tsconfig.json to force
compilation errors for unused variables. Also remove unused
variables that had crept in since the move to TypeScript.