### PR TITLE
Add climbers' initials to drop-down menus.

### DIFF
--- a/src/components/ClimbDropdown.vue
+++ b/src/components/ClimbDropdown.vue
@@ -8,7 +8,12 @@
        their menus until they need to be displayed. -->
   <v-menu lazy>
     <template v-slot:activator="{ on }">
-      <v-btn :color="stateColor" class="white--text narrow-button" v-on="on">
+      <v-btn
+        :color="stateColor"
+        class="narrow-button"
+        :class="stateTextClass"
+        v-on="on"
+      >
         {{ stateAbbrevs[syncedState] }}
       </v-btn>
     </template>
@@ -37,13 +42,19 @@ export default class ClimbDropdown extends Vue {
   // The button's 'color' property for the 'lead' state.
   // See https://vuetifyjs.com/en/styles/colors.
   @Prop(String) readonly color!: string;
+  // Identifying text (e.g. the climber's initials) to display in the button
+  // when the route hasn't been climbed.
+  @Prop(String) readonly label!: string;
 
   readonly ClimbState = ClimbState;
-  readonly stateAbbrevs: Record<ClimbState, string> = Object.freeze({
-    [ClimbState.LEAD]: 'L',
-    [ClimbState.TOP_ROPE]: 'TR',
-    [ClimbState.NOT_CLIMBED]: '',
-  });
+
+  get stateAbbrevs() {
+    return {
+      [ClimbState.LEAD]: 'L',
+      [ClimbState.TOP_ROPE]: 'TR',
+      [ClimbState.NOT_CLIMBED]: this.label,
+    };
+  }
 
   get stateColor() {
     switch (this.syncedState) {
@@ -55,11 +66,20 @@ export default class ClimbDropdown extends Vue {
         return 'grey lighten-4';
     }
   }
+
+  get stateTextClass() {
+    return this.syncedState == ClimbState.NOT_CLIMBED
+      ? 'not-climbed-button'
+      : 'white--text';
+  }
 }
 </script>
 
 <style scoped>
 .narrow-button {
   min-width: 48px;
+}
+.not-climbed-button {
+  color: #ddd;
 }
 </style>

--- a/src/components/RouteList.vue
+++ b/src/components/RouteList.vue
@@ -9,6 +9,7 @@
         <ClimbDropdown
           v-bind:state="info.states[route.id] || ClimbState.NOT_CLIMBED"
           v-bind:color="info.color"
+          v-bind:label="info.initials"
           @update:state="onUpdateClimb(i, route.id, $event)"
           class="mr-3"
         />

--- a/src/models.ts
+++ b/src/models.ts
@@ -11,11 +11,19 @@ export enum ClimbState {
 
 // ClimberInfo contains information about a climber.
 export class ClimberInfo {
+  initials: string;
+
   constructor(
     public name: string,
     public states: Record<string, ClimbState>,
     public color: string
-  ) {}
+  ) {
+    this.initials = name
+      .split(/\s+/, 3)
+      .map(w => (w ? w[0] : ''))
+      .join('')
+      .toUpperCase();
+  }
 }
 
 // Statistic contains a single item displayed in the Statistics view.


### PR DESCRIPTION
When a route hasn't been climbed yet, make ClimbDropdown's
button include the climber's initials.