### PR TITLE
Fix recursive use of StatisticsList component in prod.

### DIFF
--- a/src/components/StatisticsList.vue
+++ b/src/components/StatisticsList.vue
@@ -1,15 +1,11 @@
 <template>
   <v-list expand class="pa-0">
     <template v-for="item in items">
-      <StatisticsRow
-        :name="item.name"
-        :value="item.value"
-        v-bind:key="item.name"
-      />
+      <StatisticsRow :name="item.name" :value="item.value" :key="item.name" />
       <StatisticsList
         v-if="item.children"
         :items="item.children"
-        v-bind:key="item.name + '-children'"
+        :key="item.name + '-children'"
         class="py-0 pl-4"
       />
     </template>
@@ -22,6 +18,9 @@ import StatisticsRow from '@/components/StatisticsRow.vue';
 import { Statistic } from '@/models';
 
 @Component({
+  // The 'name' property is required for recursive components:
+  // https://github.com/kaorun343/vue-property-decorator/issues/102
+  name: 'StatisticsList',
   components: { StatisticsRow },
 })
 export default class StatisticsList extends Vue {


### PR DESCRIPTION
Explicitly set the 'name' property when declaring the
StatisticsList component. Without this, recursive
invocations (used for nested statistics) aren't expanded in
production builds.