### PR TITLE
Get rid of unnecessary v-bind: syntax.

### DIFF
--- a/src/components/RouteList.vue
+++ b/src/components/RouteList.vue
@@ -7,16 +7,16 @@
     <v-list-tile v-for="route in routes" :key="route.name">
       <v-list-tile-action v-for="(info, i) in climberInfos" :key="i">
         <ClimbDropdown
-          v-bind:state="info.states[route.id] || ClimbState.NOT_CLIMBED"
-          v-bind:color="info.color"
-          v-bind:label="info.initials"
+          :state="info.states[route.id] || ClimbState.NOT_CLIMBED"
+          :color="info.color"
+          :label="info.initials"
           @update:state="onUpdateClimb(i, route.id, $event)"
           class="mr-3"
         />
       </v-list-tile-action>
 
       <!-- Add a left margin if there aren't any climb drop-downs. -->
-      <v-list-tile-content v-bind:class="[{ 'ml-3': !climberInfos.length }]">
+      <v-list-tile-content :class="[{ 'ml-3': !climberInfos.length }]">
         <v-list-tile-title>{{ route.name }}</v-list-tile-title>
         <v-list-tile-sub-title class="details">
           <span class="grade">{{ route.grade }}</span>

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -8,7 +8,7 @@
       <v-list>
         <v-list-tile
           v-for="item in navItems"
-          v-bind:key="item.text"
+          :key="item.text"
           :to="item.route ? { name: item.route } : ''"
           v-on="item.method ? { click: item.method } : null"
         >
@@ -26,7 +26,7 @@
       color="primary"
       app
       scroll-off-screen
-      v-bind:scroll-threshold="32"
+      :scroll-threshold="32"
     >
       <v-toolbar-side-icon
         @click.stop="drawer = !drawer"

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -47,11 +47,7 @@
         <v-layout row>
           <v-flex>
             <div class="caption grey--text text--darken-1">Members</div>
-            <div
-              v-for="name in teamUserNames"
-              v-bind:key="name"
-              class="member-name"
-            >
+            <div v-for="name in teamUserNames" :key="name" class="member-name">
               {{ name }}
             </div>
           </v-flex>

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -12,8 +12,8 @@
         <div class="area">{{ area.name }}</div>
       </template>
       <RouteList
-        v-bind:climberInfos="climberInfos"
-        v-bind:routes="area.routes"
+        :climberInfos="climberInfos"
+        :routes="area.routes"
         @set-climb-state="onSetClimbState"
       />
     </v-expansion-panel-content>

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -10,11 +10,7 @@
 
       <v-tab-item key="team" value="team" v-if="teamCards.length">
         <v-container grid-list-md text-ms-center class="pt-0">
-          <v-card
-            class="pa-3 mt-3"
-            v-for="card in teamCards"
-            v-bind:key="card.name"
-          >
+          <v-card class="pa-3 mt-3" v-for="card in teamCards" :key="card.name">
             <div class="caption">{{ card.name }}</div>
             <StatisticsList :items="card.items" />
           </v-card>
@@ -23,11 +19,7 @@
 
       <v-tab-item key="user" value="user">
         <v-container grid-list-md text-ms-center class="pt-0">
-          <v-card
-            class="pa-3 mt-3"
-            v-for="card in userCards"
-            v-bind:key="card.name"
-          >
+          <v-card class="pa-3 mt-3" v-for="card in userCards" :key="card.name">
             <div class="caption">{{ card.name }}</div>
             <StatisticsList :items="card.items" />
           </v-card>


### PR DESCRIPTION
Use the ":foo" shorthand instead of the lengthier
"v-bind:foo" syntax in components.