### PR TITLE
Remove vertical padding on RouteList.

### DIFF
--- a/src/components/ClimbDropdown.vue
+++ b/src/components/ClimbDropdown.vue
@@ -10,7 +10,7 @@
     <template v-slot:activator="{ on }">
       <v-btn
         :color="stateColor"
-        class="narrow-button"
+        class="narrow-button elevation-1"
         :class="stateTextClass"
         v-on="on"
       >

--- a/src/components/RouteList.vue
+++ b/src/components/RouteList.vue
@@ -3,7 +3,7 @@
      found in the LICENSE file. -->
 
 <template>
-  <v-list two-line>
+  <v-list two-line class="py-0">
     <v-list-tile v-for="route in routes" :key="route.name">
       <v-list-tile-action v-for="(info, i) in climberInfos" :key="i">
         <ClimbDropdown


### PR DESCRIPTION
Remove weird vertical padding that the RouteList component
had by virtue of using <v-list>.

Also reduce elevation on ClimbDropdown's button since it
looked a bit heavy in the unclimbed state.