### PR TITLE
Make scoreboard exclude empty teams.

### DIFF
--- a/admin/scores.go
+++ b/admin/scores.go
@@ -45,6 +45,10 @@ func handlePostScores(ctx context.Context, w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		if len(teamData.Users) == 0 {
+			continue
+		}
+
 		summary := teamSummary{Name: teamData.Name}
 
 		// Iterate over the team's members.


### PR DESCRIPTION
Omit teams without any members from the Admin Cloud
Function's scoreboard output. These break the table layout
and aren't useful to display.