### PR TITLE
Report all errors to Stackdriver.

### DIFF
--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -95,7 +95,9 @@ export default class Routes extends Vue {
     const uid = this.teamMembers[ev.index];
 
     logInfo('set_climb_state', { user: uid, route: ev.route, state: ev.state });
-    this.teamRef.update({ ['users.' + uid + '.climbs.' + ev.route]: value });
+    this.teamRef
+      .update({ ['users.' + uid + '.climbs.' + ev.route]: value })
+      .catch(err => logError('set_climb_state_failed', err));
   }
 
   mounted() {
@@ -103,11 +105,13 @@ export default class Routes extends Vue {
       () => {
         this.loaded = true;
       },
-      error => logError('routes_load_failed', { error })
+      err => logError('routes_bind_sorted_data_failed', err)
     );
 
     this.userRef = db.collection('users').doc(getUser().uid);
-    this.$bind('userDoc', this.userRef);
+    this.$bind('userDoc', this.userRef).catch(err =>
+      logError('routes_bind_user_failed', err)
+    );
   }
 
   @Watch('userDoc.team')
@@ -116,7 +120,9 @@ export default class Routes extends Vue {
     // snapshot to the team document accordingly.
     if (this.userDoc.team) {
       this.teamRef = db.collection('teams').doc(this.userDoc.team);
-      this.$bind('teamDoc', this.teamRef);
+      this.$bind('teamDoc', this.teamRef).catch(err =>
+        logError('routes_bind_team_failed', err)
+      );
     } else {
       this.$unbind('teamDoc');
       this.teamDoc = {};

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -158,7 +158,9 @@ export default class Statistics extends Vue {
   }
 
   mounted() {
-    this.$bind('indexedData', db.collection('global').doc('indexedData'));
+    this.$bind('indexedData', db.collection('global').doc('indexedData')).catch(
+      err => logError('stats_bind_indexed_data_failed', err)
+    );
 
     bindUserAndTeamDocs(this, getUser().uid, 'userDoc', 'teamDoc').then(
       result => {
@@ -167,8 +169,11 @@ export default class Statistics extends Vue {
         this.climbDataLoaded = true;
         this.updateItems();
       },
-      error => logError('stats_load_failed', { error })
+      err => logError('stats_bind_user_and_team_failed', err)
     );
+
+    // TODO: Shouldn't we technically also watch for the user switching teams?
+    // See onTeamChanged() in Routes.vue.
   }
 }
 </script>


### PR DESCRIPTION
Register handlers that report uncaught errors and rejected
promises to Stackdriver in production builds.

Also improve existing error handling. In particular, try to
handle rejected Firestore promises, since the errors that
are logged there by default seem generic and useless.