### PR TITLE
Send log records to Stackdriver in batches.

### DIFF
--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -83,6 +83,7 @@ export function bindUserAndTeamDocs(
 
 // Only log to Stackdriver in production environments.
 const defaultLogger = new Logger(
+  'log',
   process.env.NODE_ENV == 'production'
     ? firebase.functions().httpsCallable('Log')
     : () => new Promise(resolve => resolve({ data: {} }))

--- a/src/firebase/logger.test.ts
+++ b/src/firebase/logger.test.ts
@@ -1,0 +1,256 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import firebase from 'firebase/app';
+type HttpsCallable = firebase.functions.HttpsCallable;
+type HttpsCallableResult = firebase.functions.HttpsCallableResult;
+
+import {
+  LogRecord,
+  Logger,
+  makeKeyPrefix,
+  queuedKeySuffix,
+  sendingKeySuffix,
+  lastActiveKeySuffix,
+} from './logger';
+
+// Data passed from Logger to the "Log" Cloud Function.
+class CloudFuncData {
+  constructor(public now: number, public records: LogRecord[]) {}
+}
+
+// Constructs a new LogRecord with the supplied timestamp and code.
+// Other fields are set to arbitrary hardcoded values.
+function newRecord(time: number, code: string): LogRecord {
+  return {
+    time,
+    severity: 'INFO',
+    code,
+    payload: { foo: 'bar' },
+    token: 'auth',
+  };
+}
+
+// Simulates the "Log" Cloud Function and synchronizes interactions between
+// Logger and tests.
+class Endpoint {
+  // Resolve and reject functions for the promise returned to Logger via _log.
+  _logResolve?: (data: HttpsCallableResult) => void;
+  _logReject?: (data: HttpsCallableResult) => void;
+  // Resolve function for the promise returned via handleCall.
+  _handleCallResolve?: (data?: CloudFuncData) => void;
+
+  // Data received from Logger via _log.
+  _receivedData?: CloudFuncData;
+  // Whether _log should report success to Logger.
+  _logResult: boolean = true;
+
+  // Implementation of the "Log" Cloud Function. Saves the supplied data so it
+  // can be passed to the test and returns a promise that will be fulfilled once
+  // the test has called handleCall.
+  _log(data?: any): Promise<HttpsCallableResult> {
+    return new Promise((resolve, reject) => {
+      if (this._logResolve) {
+        throw new Error('Log function called again before handleCall');
+      }
+      this._logResolve = resolve;
+      this._logReject = reject;
+      this._receivedData = data;
+      this._maybeResolvePromises();
+    });
+  }
+
+  // Called by tests to indicate the response that should be supplied to logger.
+  // The returned promise will be resolved with the data that Logger passed to
+  // _log.
+  handleCall(succeed: boolean): Promise<CloudFuncData> {
+    return new Promise(resolve => {
+      if (this._handleCallResolve) {
+        throw new Error('handleCall called again before log function');
+      }
+      this._handleCallResolve = resolve;
+      this._logResult = succeed;
+      this._maybeResolvePromises();
+    });
+  }
+
+  // Resolves the promises returned to Logger and the test if both sides are
+  // ready (i.e. Logger has called _log and the test has called handleCall).
+  // Does nothing otherwise.
+  _maybeResolvePromises() {
+    if (!this._logResolve || !this._logReject || !this._handleCallResolve) {
+      return;
+    }
+
+    this._logResult
+      ? this._logResolve({ data: { msg: 'Success' } })
+      : this._logReject({ data: { msg: 'Intentional failure' } });
+    this._handleCallResolve(this._receivedData);
+
+    this._logResolve = undefined;
+    this._logReject = undefined;
+    this._handleCallResolve = undefined;
+    this._receivedData = undefined;
+  }
+
+  // Returns the Cloud Function callable that should be passed to Logger.
+  getLogFunc(): HttpsCallable {
+    return this._log.bind(this);
+  }
+}
+
+describe('Logger', () => {
+  const name = 'test';
+  let endpoint: Endpoint;
+  let logger: Logger;
+  let now: number;
+
+  beforeEach(() => {
+    localStorage.clear();
+    now = 1;
+    endpoint = new Endpoint();
+    createLogger(5);
+  });
+
+  // Creates a new logger with the supplied logging interval.
+  function createLogger(intervalMs: number) {
+    logger = new Logger(name, endpoint.getLogFunc(), intervalMs, () => now);
+  }
+
+  // Sends relevant fields of the supplied record to logger.log.
+  function sendRecord(rec: LogRecord) {
+    logger.log(rec.severity, rec.code, rec.payload, rec.token);
+  }
+
+  it('sends individual records', done => {
+    const rec1 = newRecord(now, 'first');
+    const rec2 = newRecord(now + 1, 'second');
+
+    // Send the first record and report success.
+    sendRecord(rec1);
+    endpoint
+      .handleCall(true)
+      .then(data => {
+        // Advance the time and send a second record.
+        expect(data).toEqual(new CloudFuncData(now, [rec1]));
+        now++;
+        sendRecord(rec2);
+        return endpoint.handleCall(true);
+      })
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec2]));
+        done();
+      });
+  });
+
+  it('batches multiple records', done => {
+    const rec1 = newRecord(now, 'first');
+    const rec2 = newRecord(now, 'second');
+    const rec3 = newRecord(now, 'third');
+
+    // Send all three records without yielding and check that they're passed in
+    // a single call.
+    sendRecord(rec1);
+    sendRecord(rec2);
+    sendRecord(rec3);
+    endpoint.handleCall(true).then(data => {
+      expect(data).toEqual(new CloudFuncData(now, [rec1, rec2, rec3]));
+      done();
+    });
+  });
+
+  it('retries on failure', done => {
+    const rec = newRecord(now, 'code');
+
+    // Log a single record. Make the cloud function fail twice before
+    // succeeding.
+    sendRecord(rec);
+    endpoint
+      .handleCall(false)
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec]));
+        now++;
+        return endpoint.handleCall(false);
+      })
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec]));
+        now++;
+        return endpoint.handleCall(true);
+      })
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec]));
+        done();
+      });
+  });
+
+  it('tolerates bad data in localStorage', done => {
+    const rec1 = newRecord(now, 'first');
+    const rec2 = newRecord(now, 'second');
+
+    sendRecord(rec1);
+    endpoint
+      .handleCall(true)
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec1]));
+        // Find the 'queued' localStorage item and write junk into it. It's
+        // supposed to contain an array of LogRecord objects.
+        Object.keys(localStorage).forEach(key => {
+          if (key.endsWith('.' + queuedKeySuffix)) {
+            localStorage.setItem(key, 'bad data');
+          }
+        });
+        // When the logger is asked to send another record, it should ignore the
+        // bad data that it sees in local storage. It's important that it
+        // doesn't throw an exception, as the logger is also used to report
+        // exceptions.
+        sendRecord(rec2);
+        return endpoint.handleCall(true);
+      })
+      .then(data => {
+        expect(data).toEqual(new CloudFuncData(now, [rec2]));
+        done();
+      });
+  });
+
+  it('sends records abandoned by previous instance', done => {
+    // Set localStorage items to simulate a previous instance having left behind
+    // a queued record and an in-flight record a minute ago.
+    const oldPrefix = makeKeyPrefix(name, '12345');
+    const lastActiveKey = oldPrefix + lastActiveKeySuffix;
+    localStorage.setItem(lastActiveKey, '1');
+
+    const queuedRec = newRecord(now, 'queued');
+    const queuedKey = oldPrefix + queuedKeySuffix;
+    localStorage.setItem(queuedKey, JSON.stringify([queuedRec]));
+
+    const sendingRec = newRecord(now, 'sending');
+    const sendingKey = oldPrefix + sendingKeySuffix;
+    localStorage.setItem(sendingKey, JSON.stringify([sendingRec]));
+
+    // When a new instance is created, it should send the old records and clear
+    // the local storage entries.
+    now = 60_000;
+    createLogger(5);
+    endpoint.handleCall(true).then(data => {
+      expect(data).toEqual(new CloudFuncData(now, [sendingRec, queuedRec]));
+      expect(localStorage.getItem(lastActiveKey)).toBeNull();
+      expect(localStorage.getItem(queuedKey)).toBeNull();
+      expect(localStorage.getItem(sendingKey)).toBeNull();
+      done();
+    });
+  });
+
+  it("cleans up after previous instance that didn't leave records", () => {
+    // Set localStorage items to simulate a previous instance exiting cleanly.
+    const oldPrefix = makeKeyPrefix(name, '12345');
+    const lastActiveKey = oldPrefix + lastActiveKeySuffix;
+    localStorage.setItem(lastActiveKey, '1');
+
+    // When a new logger is created, it should delete the old last-active item,
+    // and also be able to tolerate not finding any records belonging to it.
+    now = 60_000;
+    createLogger(5);
+    expect(localStorage.getItem(lastActiveKey)).toBeNull();
+  });
+});

--- a/src/firebase/logger.ts
+++ b/src/firebase/logger.ts
@@ -6,8 +6,8 @@ import firebase from 'firebase/app';
 type HttpsCallable = firebase.functions.HttpsCallable;
 
 // LogRecord describes an individual record object sent to the "Log" Cloud
-// Function.
-interface LogRecord {
+// Function. This is exported for testing.
+export interface LogRecord {
   time: number;
   severity: string;
   code: string;
@@ -15,12 +15,59 @@ interface LogRecord {
   payload: Record<string, any>;
 }
 
-// Logger sends messages to the "Log" Cloud Function.
-export class Logger {
-  logFunc: HttpsCallable;
+// Returns the localStorage key prefix that should be used by a Logger with the
+// supplied name and ID. Exported for unit tests.
+export function makeKeyPrefix(loggerName: string, loggerID: string) {
+  return `${loggerName}.${loggerID}.`;
+}
 
-  constructor(logFunc: HttpsCallable) {
-    this.logFunc = logFunc;
+// localStorage key suffixes used for queued and in-flight log records and the
+// logger's last-active time. Exported for unit tests.
+export const queuedKeySuffix = 'queued';
+export const sendingKeySuffix = 'sending';
+export const lastActiveKeySuffix = 'lastActive';
+
+// Returns true if running under a test.
+const isTestEnv = () => process.env.NODE_ENV == 'test';
+
+// Logger sends records to the "Log" Cloud Function.
+export class Logger {
+  _name: string;
+  _logFunc: HttpsCallable;
+  _nowFunc: () => number;
+  _intervalMs: number;
+
+  // Prefix used in local storage keys. See makeKeyPrefix().
+  _storagePrefix: string;
+  // Last time _sendQueued() was called, as milliseconds since the epoch.
+  _lastSendTime: number = 0;
+  // ID of timeout used to invoke _sendQueued().
+  _sendTimeoutID: number = 0;
+
+  // name identifies the logger and should be constant across app invocations.
+  // logFunc invokes the "Log" Cloud Function.
+  // intervalMs is the minimum interval between Cloud Function invocations.
+  // nowFunc is called to get the current time as milliseconds since the epoch.
+  constructor(
+    name: string,
+    logFunc: HttpsCallable,
+    intervalMs = 10_000,
+    nowFunc = () => new Date().getTime()
+  ) {
+    this._name = name;
+    this._logFunc = logFunc;
+    this._intervalMs = intervalMs;
+    this._nowFunc = nowFunc;
+
+    // Put a random ID in localStorage key names to prevent a huge mess if the
+    // app is open in multiple tabs that are all sharing the same localStorage.
+    const id = Math.random()
+      .toString()
+      .slice(2, 2 + 8);
+    this._storagePrefix = makeKeyPrefix(name, id);
+
+    this._claimAbandonedRecords();
+    this._scheduleSend();
   }
 
   // Sends a log record to the Cloud Function.
@@ -38,13 +85,149 @@ export class Logger {
     payload: Record<string, any>,
     token?: string
   ) {
-    const time = new Date().getTime();
-    const record: LogRecord = { time, severity, code, payload };
+    const now = this._nowFunc();
+    const record: LogRecord = {
+      time: now,
+      severity,
+      code,
+      payload,
+    };
     if (token) record.token = token;
 
-    // TODO: Batch multiple records and send them all at once.
-    this.logFunc({ records: [record], now: time }).then(null, err => {
-      console.log('Failed to log', record, ':', err);
+    this._updateLastActive(now);
+    this._enqueueRecords([record]);
+    this._scheduleSend();
+  }
+
+  // Sets the logger's last-active time in localStorage to now, a timestamp as
+  // milliseconds since the epoch.
+  _updateLastActive(now: number) {
+    localStorage.setItem(
+      this._storagePrefix + lastActiveKeySuffix,
+      now.toString()
+    );
+  }
+
+  // Returns records from localStorage identified by the given key suffix
+  // (queuedKeySuffix or sendingKeySuffix).
+  _getRecords(keySuffix: string, prefix?: string): LogRecord[] {
+    const key = (prefix || this._storagePrefix) + keySuffix;
+    const s = localStorage.getItem(key);
+    if (!s) return [];
+    try {
+      return JSON.parse(s);
+    } catch (err) {
+      if (!isTestEnv()) console.error(`Failed to parse ${key}: ${err}`);
+      return [];
+    }
+  }
+
+  // Sets the localStorage key with the given suffix (queuedKeySuffix or
+  // sendingKeySuffix) to contain the supplied records.
+  _setRecords(keySuffix: string, records: LogRecord[], prefix?: string) {
+    const key = (prefix || this._storagePrefix) + keySuffix;
+    localStorage.setItem(key, JSON.stringify(records));
+  }
+
+  // Adds the supplied records to the queue.
+  _enqueueRecords(records: LogRecord[]) {
+    const queued = this._getRecords(queuedKeySuffix);
+    queued.push(...records);
+    this._setRecords(queuedKeySuffix, queued);
+  }
+
+  // Returns true if records are in-flight to the Cloud Function.
+  _currentlySending(): boolean {
+    return !!this._getRecords(sendingKeySuffix).length;
+  }
+
+  // Asynchronously sends all queued records to the Cloud Function.
+  // Records are moved to the 'sending' state while in-flight.
+  // Schedules another invocation of itself on failure.
+  _sendQueued() {
+    if (this._currentlySending()) {
+      console.error('Already sending log records');
+      return;
+    }
+
+    const now = this._nowFunc();
+    this._sendTimeoutID = 0;
+    this._lastSendTime = now;
+    this._updateLastActive(now);
+
+    // Periodically move any stale instances' records into the queue.
+    this._claimAbandonedRecords();
+
+    // Move the records from the queued state to the sending state.
+    const records = this._getRecords(queuedKeySuffix);
+    this._setRecords(sendingKeySuffix, records);
+    this._setRecords(queuedKeySuffix, []);
+
+    this._logFunc({ records, now })
+      .catch(err => {
+        // On failure, move the records back to the queue.
+        this._enqueueRecords(records);
+        if (!isTestEnv()) console.error('Failed sending log records:', err);
+      })
+      .finally(() => {
+        this._setRecords(sendingKeySuffix, []);
+        this._scheduleSend();
+      });
+  }
+
+  // Schedules a call to _sendQueued().
+  _scheduleSend() {
+    if (this._sendTimeoutID || this._currentlySending()) return;
+    // TODO: Check network status.
+    if (!this._getRecords(queuedKeySuffix).length) return;
+
+    let delayMs = 0;
+    if (this._lastSendTime > 0) {
+      const elapsedMs = this._nowFunc() - this._lastSendTime;
+      delayMs = Math.max(this._intervalMs - elapsedMs, 0);
+    }
+
+    this._sendTimeoutID = setTimeout(this._sendQueued.bind(this), delayMs);
+  }
+
+  // Iterates over localStorage and claims ownership of records abandoned by
+  // previous Logger instances.
+  _claimAbandonedRecords() {
+    Object.keys(localStorage).forEach(key => {
+      // Look for other instances' last-active times.
+      if (
+        !key.startsWith(this._name + '.') ||
+        !key.endsWith('.' + lastActiveKeySuffix)
+      ) {
+        return;
+      }
+
+      // If the other instance was recently active, leave its logs alone.
+      const lastActive = parseInt(localStorage.getItem(key) || '0');
+      if (!lastActive) return;
+      const elapsed = this._nowFunc() - lastActive;
+      if (elapsed < 2 * this._intervalMs) return;
+
+      // Chop off the suffix to get '<name>.<id>.'.
+      const prefix = key.slice(0, -lastActiveKeySuffix.length);
+
+      // Enqueue the other instance's in-flight and queued records.
+      const sending = this._getRecords(sendingKeySuffix, prefix);
+      this._enqueueRecords(sending);
+      const queued = this._getRecords(queuedKeySuffix, prefix);
+      this._enqueueRecords(queued);
+
+      // Clean up the old records.
+      localStorage.removeItem(prefix + sendingKeySuffix);
+      localStorage.removeItem(prefix + queuedKeySuffix);
+      localStorage.removeItem(key);
+
+      if (!isTestEnv()) {
+        console.log(
+          `Claimed ${sending.length} in-flight and ${queued.length} queued ` +
+            `log record(s) with prefix "${prefix}"`
+        );
+      }
     });
   }
 }


### PR DESCRIPTION
Update the Logger class to send accumulated log records just
once every 10 seconds by default, and to retry sending on
failure. Also add a bunch of unit tests.