### PR TITLE
Defer sending log records while offline.

### DIFF
--- a/src/firebase/logger.test.ts
+++ b/src/firebase/logger.test.ts
@@ -35,15 +35,15 @@ function newRecord(time: number, code: string): LogRecord {
 // Simulates the "Log" Cloud Function and synchronizes interactions between
 // Logger and tests.
 class Endpoint {
-  // Resolve and reject functions for the promise returned to Logger via _log.
+  // Resolve and reject functions for the promise returned to Logger via _log().
   _logResolve?: (data: HttpsCallableResult) => void;
   _logReject?: (data: HttpsCallableResult) => void;
-  // Resolve function for the promise returned via handleCall.
+  // Resolve function for the promise returned via handleCall().
   _handleCallResolve?: (data?: CloudFuncData) => void;
 
-  // Data received from Logger via _log.
+  // Data received from Logger via _log().
   _receivedData?: CloudFuncData;
-  // Whether _log should report success to Logger.
+  // Whether _log() should report success to Logger.
   _logResult: boolean = true;
 
   // Implementation of the "Log" Cloud Function. Saves the supplied data so it
@@ -61,9 +61,9 @@ class Endpoint {
     });
   }
 
-  // Called by tests to indicate the response that should be supplied to logger.
+  // Called by tests to indicate the response that should be supplied to Logger.
   // The returned promise will be resolved with the data that Logger passed to
-  // _log.
+  // _log().
   handleCall(succeed: boolean): Promise<CloudFuncData> {
     return new Promise(resolve => {
       if (this._handleCallResolve) {
@@ -76,7 +76,7 @@ class Endpoint {
   }
 
   // Resolves the promises returned to Logger and the test if both sides are
-  // ready (i.e. Logger has called _log and the test has called handleCall).
+  // ready (i.e. Logger has called _log() and the test has called handleCall()).
   // Does nothing otherwise.
   _maybeResolvePromises() {
     if (!this._logResolve || !this._logReject || !this._handleCallResolve) {
@@ -101,26 +101,57 @@ class Endpoint {
 }
 
 describe('Logger', () => {
+  // Logger name.
   const name = 'test';
+
+  // Simulates the Cloud Function.
   let endpoint: Endpoint;
+  // Object being tested.
   let logger: Logger;
+
+  // Time returned by logger._now(), as milliseconds since the epoch.
   let now: number;
+  // State returned by logger._online().
+  let online: boolean;
+  // Mock implementation of window.addEventListener.
+  let addEventListenerMock: jest.Mock;
 
   beforeEach(() => {
+    // Capture calls to window.addEventListener.
+    addEventListenerMock = jest.fn();
+    window.addEventListener = addEventListenerMock;
+
     localStorage.clear();
     now = 1;
+    online = true;
     endpoint = new Endpoint();
     createLogger(5);
   });
 
-  // Creates a new logger with the supplied logging interval.
+  // Creates a new Logger with the supplied logging interval.
   function createLogger(intervalMs: number) {
-    logger = new Logger(name, endpoint.getLogFunc(), intervalMs, () => now);
+    logger = new Logger(
+      name,
+      endpoint.getLogFunc(),
+      intervalMs,
+      () => now,
+      () => online
+    );
   }
 
   // Sends relevant fields of the supplied record to logger.log.
   function sendRecord(rec: LogRecord) {
     logger.log(rec.severity, rec.code, rec.payload, rec.token);
+  }
+
+  // Calls all listeners previously passed to window.addEventListener for event
+  // |name|. At present, doesn't actually send them an event or handle removed
+  // listeners.
+  function callListeners(name: string) {
+    for (let i = 0; i < addEventListenerMock.mock.calls.length; i++) {
+      const call = addEventListenerMock.mock.calls[i];
+      if (call[0] == name) call[1]();
+    }
   }
 
   it('sends individual records', done => {
@@ -134,12 +165,14 @@ describe('Logger', () => {
       .then(data => {
         // Advance the time and send a second record.
         expect(data).toEqual(new CloudFuncData(now, [rec1]));
+        expect(logger.isSendScheduled()).toBe(false);
         now++;
         sendRecord(rec2);
         return endpoint.handleCall(true);
       })
       .then(data => {
         expect(data).toEqual(new CloudFuncData(now, [rec2]));
+        expect(logger.isSendScheduled()).toBe(false);
         done();
       });
   });
@@ -156,6 +189,7 @@ describe('Logger', () => {
     sendRecord(rec3);
     endpoint.handleCall(true).then(data => {
       expect(data).toEqual(new CloudFuncData(now, [rec1, rec2, rec3]));
+      expect(logger.isSendScheduled()).toBe(false);
       done();
     });
   });
@@ -180,6 +214,7 @@ describe('Logger', () => {
       })
       .then(data => {
         expect(data).toEqual(new CloudFuncData(now, [rec]));
+        expect(logger.isSendScheduled()).toBe(false);
         done();
       });
   });
@@ -209,6 +244,7 @@ describe('Logger', () => {
       })
       .then(data => {
         expect(data).toEqual(new CloudFuncData(now, [rec2]));
+        expect(logger.isSendScheduled()).toBe(false);
         done();
       });
   });
@@ -234,6 +270,7 @@ describe('Logger', () => {
     createLogger(5);
     endpoint.handleCall(true).then(data => {
       expect(data).toEqual(new CloudFuncData(now, [sendingRec, queuedRec]));
+      expect(logger.isSendScheduled()).toBe(false);
       expect(localStorage.getItem(lastActiveKey)).toBeNull();
       expect(localStorage.getItem(queuedKey)).toBeNull();
       expect(localStorage.getItem(sendingKey)).toBeNull();
@@ -252,5 +289,26 @@ describe('Logger', () => {
     now = 60_000;
     createLogger(5);
     expect(localStorage.getItem(lastActiveKey)).toBeNull();
+    expect(logger.isSendScheduled()).toBe(false);
+  });
+
+  it('defers sending records while offline', done => {
+    // Logger shouldn't schedule sending records while offline.
+    online = false;
+    const rec = newRecord(now, 'code');
+    sendRecord(rec);
+    expect(logger.isSendScheduled()).toBe(false);
+
+    // Simulate the browser coming online.
+    now++;
+    online = true;
+    callListeners('online');
+
+    // The record should be sent now.
+    endpoint.handleCall(true).then(data => {
+      expect(data).toEqual(new CloudFuncData(now, [rec]));
+      expect(logger.isSendScheduled()).toBe(false);
+      done();
+    });
   });
 });

--- a/src/firebase/logger.ts
+++ b/src/firebase/logger.ts
@@ -22,7 +22,8 @@ export function makeKeyPrefix(loggerName: string, loggerID: string) {
 }
 
 // localStorage key suffixes used for queued and in-flight log records and the
-// logger's last-active time. Exported for unit tests.
+// logger's last-active time (as milliseconds since the epoch). Exported for
+// unit tests.
 export const queuedKeySuffix = 'queued';
 export const sendingKeySuffix = 'sending';
 export const lastActiveKeySuffix = 'lastActive';
@@ -34,8 +35,9 @@ const isTestEnv = () => process.env.NODE_ENV == 'test';
 export class Logger {
   _name: string;
   _logFunc: HttpsCallable;
-  _nowFunc: () => number;
   _intervalMs: number;
+  _now: () => number;
+  _online: () => boolean;
 
   // Prefix used in local storage keys. See makeKeyPrefix().
   _storagePrefix: string;
@@ -43,21 +45,28 @@ export class Logger {
   _lastSendTime: number = 0;
   // ID of timeout used to invoke _sendQueued().
   _sendTimeoutID: number = 0;
+  // Callback for online events.
+  _handleOnline: () => void;
 
-  // name identifies the logger and should be constant across app invocations.
-  // logFunc invokes the "Log" Cloud Function.
-  // intervalMs is the minimum interval between Cloud Function invocations.
-  // nowFunc is called to get the current time as milliseconds since the epoch.
+  // |name| identifies the logger and should be constant across app invocations.
+  // |logFunc| invokes the "Log" Cloud Function.
+  // |intervalMs| is the minimum interval between Cloud Function invocations.
+  // |nowFunc| is called to get the current time as milliseconds since the
+  // epoch; it can be provided by tests to control time.
+  // |onlineFunc| is called to get the current online state and can be
+  // provided by tests.
   constructor(
     name: string,
     logFunc: HttpsCallable,
     intervalMs = 10_000,
-    nowFunc = () => new Date().getTime()
+    nowFunc = () => new Date().getTime(),
+    onlineFunc = () => navigator.onLine
   ) {
     this._name = name;
     this._logFunc = logFunc;
     this._intervalMs = intervalMs;
-    this._nowFunc = nowFunc;
+    this._now = nowFunc;
+    this._online = onlineFunc;
 
     // Put a random ID in localStorage key names to prevent a huge mess if the
     // app is open in multiple tabs that are all sharing the same localStorage.
@@ -68,24 +77,34 @@ export class Logger {
 
     this._claimAbandonedRecords();
     this._scheduleSend();
+
+    // We hold off on sending records while offline, so try to send queued
+    // records whenever coming back online.
+    this._handleOnline = () => this._scheduleSend();
+    window.addEventListener('online', this._handleOnline);
   }
 
-  // Sends a log record to the Cloud Function.
-  // severity is a case-insensitive Severity level from
+  // Removes event listeners so the object can be garbage-collected.
+  destroy() {
+    window.removeEventListener('online', this._handleOnline);
+  }
+
+  // Asynchronously sends a log record to the Cloud Function.
+  // |severity| is a case-insensitive Severity level from
   // https://godoc.org/cloud.google.com/go/logging#pkg-constants, e.g. 'INFO'.
-  // code uniquely identifies the type of event, e.g. 'load_app' or
+  // |code| uniquely identifies the type of event, e.g. 'load_app' or
   // 'set_user_name'.
-  // payload contains structured data describing the event, e.g.
+  // |payload| contains structured data describing the event, e.g.
   // {userAgent: 'Foo'}.
-  // If token is supplied, it contains a Firebase auth token that can be used to
-  // derive the UID of the current user.
+  // If |token| is supplied, it contains a Firebase auth token that can be used
+  // to derive the UID of the current user.
   log(
     severity: string,
     code: string,
     payload: Record<string, any>,
     token?: string
   ) {
-    const now = this._nowFunc();
+    const now = this._now();
     const record: LogRecord = {
       time: now,
       severity,
@@ -108,8 +127,8 @@ export class Logger {
     );
   }
 
-  // Returns records from localStorage identified by the given key suffix
-  // (queuedKeySuffix or sendingKeySuffix).
+  // Returns records from localStorage identified by |keySuffix|
+  // (|queuedKeySuffix| or |sendingKeySuffix|).
   _getRecords(keySuffix: string, prefix?: string): LogRecord[] {
     const key = (prefix || this._storagePrefix) + keySuffix;
     const s = localStorage.getItem(key);
@@ -122,22 +141,28 @@ export class Logger {
     }
   }
 
-  // Sets the localStorage key with the given suffix (queuedKeySuffix or
-  // sendingKeySuffix) to contain the supplied records.
+  // Sets the localStorage item identified by |keySuffix| (|queuedKeySuffix| or
+  // |sendingKeySuffix|) to contain |records|.
   _setRecords(keySuffix: string, records: LogRecord[], prefix?: string) {
     const key = (prefix || this._storagePrefix) + keySuffix;
     localStorage.setItem(key, JSON.stringify(records));
   }
 
-  // Adds the supplied records to the queue.
+  // Adds |records| to the end of the queue.
   _enqueueRecords(records: LogRecord[]) {
     const queued = this._getRecords(queuedKeySuffix);
     queued.push(...records);
     this._setRecords(queuedKeySuffix, queued);
   }
 
-  // Returns true if records are in-flight to the Cloud Function.
-  _currentlySending(): boolean {
+  // Returns true if a call to _sendQueued() is scheduled. Exposed so that tests
+  // can verify that the class is idle.
+  isSendScheduled() {
+    return !!this._sendTimeoutID;
+  }
+
+  // Returns true if any records are in-flight to the Cloud Function.
+  _currentlySending() {
     return !!this._getRecords(sendingKeySuffix).length;
   }
 
@@ -150,7 +175,7 @@ export class Logger {
       return;
     }
 
-    const now = this._nowFunc();
+    const now = this._now();
     this._sendTimeoutID = 0;
     this._lastSendTime = now;
     this._updateLastActive(now);
@@ -177,17 +202,23 @@ export class Logger {
 
   // Schedules a call to _sendQueued().
   _scheduleSend() {
-    if (this._sendTimeoutID || this._currentlySending()) return;
-    // TODO: Check network status.
+    if (this.isSendScheduled() || this._currentlySending()) return;
+    if (!this._online()) return;
     if (!this._getRecords(queuedKeySuffix).length) return;
 
     let delayMs = 0;
     if (this._lastSendTime > 0) {
-      const elapsedMs = this._nowFunc() - this._lastSendTime;
+      const elapsedMs = this._now() - this._lastSendTime;
       delayMs = Math.max(this._intervalMs - elapsedMs, 0);
     }
 
-    this._sendTimeoutID = setTimeout(this._sendQueued.bind(this), delayMs);
+    // window.setTimeout() is necessary here rather than setTimeout(), as we get
+    // the Node TS definition otherwise (which returns a Timeout rather than a
+    // number): https://stackoverflow.com/q/45802988
+    this._sendTimeoutID = window.setTimeout(
+      this._sendQueued.bind(this),
+      delayMs
+    );
   }
 
   // Iterates over localStorage and claims ownership of records abandoned by
@@ -205,7 +236,7 @@ export class Logger {
       // If the other instance was recently active, leave its logs alone.
       const lastActive = parseInt(localStorage.getItem(key) || '0');
       if (!lastActive) return;
-      const elapsed = this._nowFunc() - lastActive;
+      const elapsed = this._now() - lastActive;
       if (elapsed < 2 * this._intervalMs) return;
 
       // Chop off the suffix to get '<name>.<id>.'.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "types": ["jest", "vuetify", "webpack-env"],
+    "types": ["jest", "node", "vuetify", "webpack-env"],
     "paths": {
       "@/*": ["src/*"]
     },


### PR DESCRIPTION
Make the Logger class hold off on scheduling _sendQueued()
calls when the browser reports that the device was offline.
As soon as the device comes online, we schedule sending.

I'm also adding Node types to our TypeScript config. I'm not
completely sure that we'll need this, though, as zero lucks
were given when I tried to mock the navigator.onLine
property in tests.

Finally, I improved comments a bit and switched to Chrome's
style of putting parameter names in pipes (e.g. "Subscribed
to events of type |name|.") to make them easier to read.