### PR TITLE
Report performance data.

### DIFF
--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -81,10 +81,15 @@ export function bindUserAndTeamDocs(
   });
 }
 
+// Change this to true to send logs to Stackdriver in dev environments.
+// By default, we only send logs in production.
+const logForDev = false;
+
 // Only log to Stackdriver in production environments.
 const defaultLogger = new Logger(
   'log',
-  process.env.NODE_ENV == 'production'
+  process.env.NODE_ENV == 'production' ||
+  (logForDev && process.env.NODE_ENV == 'dev')
     ? firebase.functions().httpsCallable('Log')
     : () => new Promise(resolve => resolve({ data: {} }))
 );
@@ -103,6 +108,11 @@ function log(severity: string, code: string, payload: Record<string, any>) {
       token => defaultLogger.log(severity, code, payload, token),
       err => console.log('Failed to get ID token:', err)
     );
+}
+
+// Sends a record to Stackdriver with DEBUG severity.
+export function logDebug(code: string, payload: Record<string, any>) {
+  log('DEBUG', code, payload);
 }
 
 // Sends a record to Stackdriver with INFO severity.

--- a/src/mixins/Perf.ts
+++ b/src/mixins/Perf.ts
@@ -1,0 +1,53 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import Vue from 'vue';
+import Component from 'vue-class-component';
+
+import { logDebug } from '@/firebase';
+
+@Component
+export default class Perf extends Vue {
+  constructed: DOMHighResTimeStamp;
+  eventTimestamps: Record<string, DOMHighResTimeStamp> = {};
+  loggedReady = false;
+
+  constructor() {
+    super();
+    this.constructed = window.performance.now();
+  }
+
+  // Records timestamps when the Vue and its components are mounted.
+  // This is a lifecycle hook and shouldn't be called manually.
+  mounted() {
+    this.recordEvent('mounted');
+    // Also report when child components have been mounted:
+    // https://vuejs.org/v2/api/#mounted
+    this.$nextTick(() => this.recordEvent('rendered'));
+  }
+
+  // Records a timestamp for an event identified by |name|. Views using this
+  // mixin should call this to report significant events.
+  recordEvent(name: string) {
+    this.eventTimestamps[name] = window.performance.now();
+  }
+
+  // Adds a 'ready' timestamp and reports performance data. Views using this
+  // mixin should call this once when they are fully loaded.
+  logReady(code: string) {
+    if (this.loggedReady) return;
+
+    this.recordEvent('ready');
+
+    // Construct a payload mapping from event name to elapsed time in
+    // milliseconds.
+    const payload: Record<string, any> = {};
+    for (const name of Object.keys(this.eventTimestamps)) {
+      payload[name] = Math.round(this.eventTimestamps[name] - this.constructed);
+    }
+    logDebug(code, payload);
+
+    this.loggedReady = true;
+  }
+}

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -209,7 +209,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Mixins } from 'vue-property-decorator';
 
 import firebase from 'firebase/app';
 type DocumentReference = firebase.firestore.DocumentReference;
@@ -224,12 +224,13 @@ import {
 import { ClimbState, User, Team } from '@/models';
 import Card from '@/components/Card.vue';
 import DialogCard from '@/components/DialogCard.vue';
+import Perf from '@/mixins/Perf.ts';
 import Spinner from '@/components/Spinner.vue';
 
 @Component({
   components: { Card, DialogCard, Spinner },
 })
-export default class Profile extends Vue {
+export default class Profile extends Mixins(Perf) {
   // Maximum length of user and team names.
   readonly nameMaxLength = 50;
 
@@ -540,6 +541,7 @@ export default class Profile extends Vue {
         this.userRef = result.user;
         this.teamRef = result.team;
         this.ready = true;
+        this.logReady('profile_loaded');
       },
       err => logError('profile_initial_bind_failed', err)
     );


### PR DESCRIPTION
Add a new 'Perf' Vue mixin that views can use to report
their initial load times to Stackdriver at DEBUG severity.

Also update views to report 'profile_loaded',
'routes_loaded', and 'stats_loaded' records.