### PR TITLE
Add UserLoader mixin.

### DIFF
--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -10,9 +10,6 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 import 'firebase/functions';
-type DocumentReference = firebase.firestore.DocumentReference;
-
-import Vue from 'vue';
 
 import { Logger } from './logger';
 
@@ -35,42 +32,6 @@ export function getUser() {
     throw new Error('No current user');
   }
   return auth.currentUser;
-}
-
-// DocRefs contains references to documents in the 'users' and (optionally)
-// 'teams' collections and is returned by bindUserAndTeamDocs.
-interface DocRefs {
-  user: DocumentReference;
-  team: DocumentReference | null;
-}
-
-// Returns a promise that is satisfied once document snapshot(s) are loaded.
-// The user and team documents (if present) are bound to properties named
-// userProp and teamProp on view.
-export function bindUserAndTeamDocs(
-  view: Vue,
-  userId: string,
-  userProp: string,
-  teamProp: string
-): Promise<DocRefs> {
-  return new Promise((resolve, reject) => {
-    const userRef = db.collection('users').doc(userId);
-    view.$bind(userProp, userRef).then(
-      userSnap => {
-        if (!userSnap.team) {
-          resolve({ user: userRef, team: null });
-          return;
-        }
-        const teamRef = db.collection('teams').doc(userSnap.team);
-        view.$bind(teamProp, teamRef).then(() => {
-          resolve({ user: userRef, team: teamRef });
-        });
-      },
-      err => {
-        reject(err);
-      }
-    );
-  });
 }
 
 enum LogDest {

--- a/src/mixins/Perf.ts
+++ b/src/mixins/Perf.ts
@@ -3,8 +3,7 @@
 // found in the LICENSE file.
 
 import Vue from 'vue';
-import Component from 'vue-class-component';
-
+import { Component } from 'vue-property-decorator';
 import { logDebug } from '@/firebase';
 
 @Component

--- a/src/mixins/UserLoader.ts
+++ b/src/mixins/UserLoader.ts
@@ -1,0 +1,73 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+import { db, getUser } from '@/firebase';
+import { User, Team } from '@/models';
+
+type DocumentReference = firebase.firestore.DocumentReference;
+
+// The UserLoader mixin component automatically binds the Firestore user
+// document (i.e. 'users/<uid>' to |userDoc| and |userRef| data properties.
+//
+// If the user is on a team, it also binds the team document (i.e.
+// 'teams/<team_id>') to |teamDoc| and |teamRef|, updating those properties if
+// the user leaves the team or joins a new one.
+@Component
+export default class UserLoader extends Vue {
+  // Snapshot and reference for user document.
+  userDoc: Partial<User> = {};
+  userRef: DocumentReference | null = null;
+
+  // Snapshot and reference for team document.
+  teamDoc: Partial<Team> = {};
+  teamRef: DocumentReference | null = null;
+
+  // Components using this mixin should watch the following data properties to
+  // observe load-related events.
+  //
+  // Set to true after user (and team, if applicable) docs are loaded. This
+  // should only have a single transition from false to true after the initial
+  // load completes successfully.
+  userLoaded = false;
+  // Set if user or team document fails to load. Note that this may be set
+  // multiple times: the team document is rebound if the user switches teams.
+  userLoadError: Error | null = null;
+
+  mounted() {
+    // Kick things off by loading the user doc.
+    this.userRef = db.collection('users').doc(getUser().uid);
+    this.$bind('userDoc', this.userRef)
+      .then(userSnap => {
+        // If the user isn't on a team, then we're done. Otherwise,
+        // onTeamChanged will handle setting userReady after it loads the team
+        // doc.
+        if (userSnap['team'] === undefined) this.userLoaded = true;
+      })
+      .catch(err => {
+        this.userLoadError = err;
+      });
+  }
+
+  @Watch('userDoc.team')
+  onTeamChanged() {
+    // When the team ID in the user doc changes, update the reference and
+    // snapshot for the team document accordingly.
+    if (this.userDoc.team) {
+      this.teamRef = db.collection('teams').doc(this.userDoc.team);
+      this.$bind('teamDoc', this.teamRef)
+        .then(() => {
+          this.userLoaded = true;
+        })
+        .catch(err => {
+          this.userLoadError = err;
+        });
+    } else {
+      this.$unbind('teamDoc');
+      this.teamDoc = {};
+      this.teamRef = null;
+    }
+  }
+}


### PR DESCRIPTION
Add a new UserLoader mixin component that automatically
loads the user and team (if applicable) documents from
Firestore and watches for team changes.

This replaces duplicated (and incorrect, in some cases) code
from the Profile, Routes, and Statistics views.