### PR TITLE
Split firebase/index.ts into more files.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { auth } from '@/firebase';
+import { auth } from '@/firebase/auth';
 
 import Perf from '@/mixins/Perf.ts';
 import Toolbar from '@/components/Toolbar.vue';

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -39,7 +39,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { auth } from '@/firebase';
+import { auth } from '@/firebase/auth';
 
 // An entry in the navigation drawer.
 interface NavItem {

--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -1,0 +1,20 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file exposes auth-related functionality from Firebase.
+
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import './init';
+
+export const auth = firebase.auth();
+
+// getUser returns the firebase.auth.User for the currently-logged in user.
+// An error is thrown if the user is not logged in.
+export function getUser() {
+  if (!auth.currentUser) {
+    throw new Error('No current user');
+  }
+  return auth.currentUser;
+}

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -1,0 +1,20 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file exposes Cloud-Firestore-related functionality from Firebase.
+
+import firebase from 'firebase/app';
+import 'firebase/firestore';
+import './init';
+
+export const db = firebase.firestore();
+
+// See https://firebase.google.com/docs/firestore/manage-data/enable-offline.
+db.enablePersistence().catch(function(err) {
+  if (err.code == 'failed-precondition') {
+    console.log('Firestore persistence unavailable (multiple tabs open)');
+  } else if (err.code == 'unimplemented') {
+    console.log('Firestore persistence unsupported by browser');
+  }
+});

--- a/src/firebase/functions.ts
+++ b/src/firebase/functions.ts
@@ -1,0 +1,11 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file exposes Cloud-Function-related functionality from Firebase.
+
+import firebase from 'firebase/app';
+import 'firebase/functions';
+import './init';
+
+export const functions = firebase.functions();

--- a/src/firebase/init.ts
+++ b/src/firebase/init.ts
@@ -1,0 +1,18 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file initializes Firebase. It is imported for its side effects by other
+// files in this directory.
+
+import firebase from 'firebase/app';
+
+firebase.initializeApp({
+  apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
+  authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.VUE_APP_FIREBASE_DATABASE_URL,
+  projectId: process.env.VUE_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VUE_APP_FIREBASE_APP_ID,
+});

--- a/src/log/index.ts
+++ b/src/log/index.ts
@@ -2,46 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This file initializes Firebase and exports various Firebase-related objects
-// so they can be used by components.
-
-import firebase from 'firebase/app';
-import 'firebase/auth';
-import 'firebase/firestore';
-import 'firebase/functions';
-
-import { Logger } from './logger';
-
-firebase.initializeApp({
-  apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
-  authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.VUE_APP_FIREBASE_DATABASE_URL,
-  projectId: process.env.VUE_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.VUE_APP_FIREBASE_APP_ID,
-});
-
-export const auth = firebase.auth();
-export const db = firebase.firestore();
-
-// See https://firebase.google.com/docs/firestore/manage-data/enable-offline.
-db.enablePersistence().catch(function(err) {
-  if (err.code == 'failed-precondition') {
-    console.log('Firestore persistence unavailable (multiple tabs open)');
-  } else if (err.code == 'unimplemented') {
-    console.log('Firestore persistence unsupported by browser');
-  }
-});
-
-// getUser returns the firebase.auth.User for the currently-logged in user.
-// An error is thrown if the user is not logged in.
-export function getUser() {
-  if (!auth.currentUser) {
-    throw new Error('No current user');
-  }
-  return auth.currentUser;
-}
+import { Logger, LogFunc } from './logger';
 
 enum LogDest {
   STACKDRIVER,
@@ -57,9 +18,13 @@ const isTest = process.env.NODE_ENV == 'test';
 let devLogDest = LogDest.NONE;
 
 // Returns an appropriate function to pass to the default Logger.
-function getLogFunc(): firebase.functions.HttpsCallable {
+function getLogFunc(): LogFunc | Promise<LogFunc> {
   if (isProd || (isDev && devLogDest == LogDest.STACKDRIVER)) {
-    return firebase.functions().httpsCallable('Log');
+    // Import the module asynchronously and return a promise so that importing
+    // this module doesn't require synchronously loading bulky Firebase code.
+    return import('@/firebase/functions').then(fn =>
+      fn.functions.httpsCallable('Log')
+    );
   }
   if (isDev && devLogDest == LogDest.CONSOLE) {
     return (data?: any) => {
@@ -75,17 +40,25 @@ const defaultLogger = new Logger('log', getLogFunc());
 // Helper function that sends a log message to Stackdriver.
 // See the Logger class's log method for more details.
 function log(severity: string, code: string, payload: Record<string, any>) {
-  if (!auth.currentUser) {
-    defaultLogger.log(severity, code, payload);
-    return;
-  }
-
-  auth.currentUser
-    .getIdToken()
-    .then(
-      token => defaultLogger.log(severity, code, payload, token),
-      err => console.log('Failed to get ID token:', err)
-    );
+  // Import the module asynchronously so that importing this module doesn't
+  // require synchronously loading bulky Firebase code.
+  import('@/firebase/auth')
+    .then(auth => {
+      const user = auth.getUser();
+      if (!user) {
+        defaultLogger.log(severity, code, payload);
+        return;
+      }
+      user
+        .getIdToken()
+        .then(
+          token => defaultLogger.log(severity, code, payload, token),
+          err => console.log('Failed to get ID token:', err)
+        );
+    })
+    .catch(err => {
+      console.error(`Failed to import Firebase auth code: ${err}`);
+    });
 }
 
 // Sends a record to Stackdriver with DEBUG severity.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { auth, logError } from '@/firebase';
+import { auth } from '@/firebase/auth';
+import { logError } from '@/log';
 
 const isTestEnv = process.env.NODE_ENV == 'test';
 

--- a/src/mixins/Perf.ts
+++ b/src/mixins/Perf.ts
@@ -4,7 +4,7 @@
 
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
-import { logDebug } from '@/firebase';
+import { logDebug } from '@/log';
 
 @Component
 export default class Perf extends Vue {

--- a/src/mixins/UserLoader.ts
+++ b/src/mixins/UserLoader.ts
@@ -4,7 +4,8 @@
 
 import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
-import { db, getUser } from '@/firebase';
+import { getUser } from '@/firebase/auth';
+import { db } from '@/firebase/firestore';
 import { User, Team } from '@/models';
 
 type DocumentReference = firebase.firestore.DocumentReference;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,7 +7,7 @@
 
 import VueRouter from 'vue-router';
 
-import { auth } from '@/firebase';
+import { auth } from '@/firebase/auth';
 
 // Lazily load the Login view since it imports firebaseui, which is 200+ KB.
 // See https://alexjover.com/blog/lazy-load-in-vue-using-webpack-s-code-splitting/

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -33,7 +33,9 @@ import { Component, Mixins, Watch } from 'vue-property-decorator';
 import firebase from 'firebase/app';
 import firebaseui from 'firebaseui';
 
-import { auth, db, getUser, logInfo } from '@/firebase';
+import { auth, getUser } from '@/firebase/auth';
+import { db } from '@/firebase/firestore';
+import { logInfo } from '@/log';
 import Card from '@/components/Card.vue';
 import Perf from '@/mixins/Perf.ts';
 import Spinner from '@/components/Spinner.vue';

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -260,7 +260,9 @@ import { Component, Mixins, Watch } from 'vue-property-decorator';
 import firebase from 'firebase/app';
 type DocumentReference = firebase.firestore.DocumentReference;
 
-import { db, getUser, logInfo, logError } from '@/firebase';
+import { getUser } from '@/firebase/auth';
+import { db } from '@/firebase/firestore';
+import { logInfo, logError } from '@/log';
 import { ClimbState } from '@/models';
 import Card from '@/components/Card.vue';
 import DialogCard from '@/components/DialogCard.vue';

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -26,7 +26,8 @@ import { Component, Mixins, Watch } from 'vue-property-decorator';
 
 import firebase from 'firebase/app';
 
-import { db, logInfo, logError } from '@/firebase';
+import { db } from '@/firebase/firestore';
+import { logInfo, logError } from '@/log';
 import {
   ClimberInfo,
   ClimbState,

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -40,7 +40,9 @@
 
 <script lang="ts">
 import { Component, Mixins, Watch } from 'vue-property-decorator';
-import { db, getUser, logError } from '@/firebase';
+import { getUser } from '@/firebase/auth';
+import { db } from '@/firebase/firestore';
+import { logError } from '@/log';
 import { ClimbState, Statistic, IndexedData } from '@/models';
 import Card from '@/components/Card.vue';
 import Perf from '@/mixins/Perf.ts';


### PR DESCRIPTION
Split the monolithic firebase/index.ts file into separate
auth.ts, firestore.ts, functions.ts, and init.ts files to
make it easier for other files to import just the necessary
functionality.

Also move the logging-specific code into a new log
directory. It has minimal Firebase dependencies, so refactor
it slightly so it can be imported without pulling in
the bulky Firebase libraries.