### PR TITLE
Enable tab-syncing for Firestore persistence.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@
       <router-view
         @success-msg="onMessage($event, 'success', 3000)"
         @error-msg="onMessage($event, 'error', 6000)"
+        @warning-msg="onMessage($event, 'warning', 6000)"
         @info-msg="onMessage($event, 'info', 3000)"
       />
 

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -24,7 +24,11 @@
 <script lang="ts">
 import { Component, Mixins, Watch } from 'vue-property-decorator';
 
-import { getFirestore } from '@/firebase';
+import {
+  getFirestore,
+  getFirestorePersistence,
+  FirestorePersistence,
+} from '@/firebase';
 import { logInfo, logError } from '@/log';
 import {
   ClimberInfo,
@@ -122,6 +126,12 @@ export default class Routes extends Mixins(Perf, UserLoader) {
         () => {
           this.loadedSortedData = true;
           this.recordEvent('loadedSortedData');
+
+          // Display a warning to the user if offline Firestore is unavailable.
+          // TODO: Would it be better to just display this once?
+          if (getFirestorePersistence() == FirestorePersistence.DISABLED) {
+            this.$emit('warning-msg', 'Offline mode unsupported');
+          }
         },
         err => {
           this.$emit('error-msg', `Failed loading route data: {err}`);


### PR DESCRIPTION
I didn't notice it before, but there's an option to tell
Firestore to sync its state between tabs, which allows
persistence a.k.a. offline mode to be used when the site is
open in multiple tabs (which can happen easily after
installing the PWA). Pass this when enabling persistence.

Also make the Routes view display a warning if persistence
is disabled for some reason (ancient browser?).