### PR TITLE
Add confirmation dialog for "Sign out" nav item.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "test:unit:only": "vue-cli-service test:unit --testPathPattern"
   },
   "dependencies": {
     "core-js": "^2.6.5",

--- a/src/components/Toolbar.test.ts
+++ b/src/components/Toolbar.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import { MockFirebase } from '@/firebase/mock';
+
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import VueRouter from 'vue-router';
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+
+import { getValue } from '@/testutil';
+import routes from '@/router/routes';
+import Toolbar from './Toolbar.vue';
+
+Vue.use(Vuetify);
+
+describe('Toolbar', () => {
+  let wrapper: Wrapper<Vue>;
+
+  beforeEach(() => {
+    MockFirebase.reset();
+
+    // Avoid Vuetify log spam: https://github.com/vuetifyjs/vuetify/issues/3456
+    const el = document.createElement('div');
+    el.setAttribute('data-app', 'true');
+    document.body.appendChild(el);
+
+    // See https://vue-test-utils.vuejs.org/guides/using-with-vue-router.html.
+    const localVue = createLocalVue();
+    localVue.use(VueRouter);
+    const router = new VueRouter({ mode: 'abstract', routes });
+    wrapper = mount(Toolbar, { localVue, router });
+  });
+
+  function findRef(ref: string): Wrapper<Vue> {
+    return wrapper.find({ ref });
+  }
+
+  it('toggles the navigation drawer when the icon is clicked', () => {
+    const drawer = findRef('drawer');
+    expect(getValue(drawer)).toBeFalsy();
+
+    const icon = findRef('toolbarIcon');
+    icon.trigger('click');
+    expect(getValue(drawer)).toBeTruthy();
+
+    icon.trigger('click');
+    expect(getValue(drawer)).toBeFalsy();
+  });
+
+  it('prompts before signing out', async () => {
+    const dialog = findRef('signOutDialog');
+    expect(getValue(dialog)).toBeFalsy();
+    expect(MockFirebase.currentUser).toBeTruthy();
+
+    // Open the navigation drawer and click the last tile.
+    // Use vm.$emit instead of trigger: // https://stackoverflow.com/q/52058141
+    findRef('toolbarIcon').trigger('click');
+    const tiles = wrapper.findAll({ name: 'v-list-tile' });
+    tiles.at(tiles.length - 1).vm.$emit('click');
+
+    // Click the confirm button in the dialog.
+    expect(getValue(dialog)).toBeTruthy();
+    findRef('confirmSignOutButton').trigger('click');
+    await flushPromises();
+
+    // The user should be signed out and we should navigate to the login view.
+    expect(MockFirebase.currentUser).toBeNull();
+    expect(wrapper.vm.$route.name).toBe('login');
+  });
+
+  // TODO: Ideally we'd also test that the navigation links work, but doing so
+  // is beyond me. After I call trigger('click') on one of the v-list-tile
+  // elements in the navigation drawer, wrapper.vm.$route and
+  // router.currentRoute are both empty objects. This is probably an issue
+  // related to router-link (which v-list-tile extends), since navigation works
+  // in the signout test when it's triggered by $router.replace().
+});

--- a/src/firebase/mock.ts
+++ b/src/firebase/mock.ts
@@ -272,6 +272,12 @@ jest.mock('firebase/app', () => {
           observer(MockFirebase.currentUser);
         });
       },
+      signOut: () => {
+        MockFirebase.currentUser = null;
+        return new Promise(resolve => {
+          resolve();
+        });
+      },
     }),
     firestore: () => ({
       batch: () => new MockWriteBatch(),

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,44 +7,9 @@
 
 import VueRouter from 'vue-router';
 import { getAuth } from '@/firebase';
+import routes from './routes';
 
-import Login from '@/views/Login.vue';
-import Profile from '@/views/Profile.vue';
-import Routes from '@/views/Routes.vue';
-import Statistics from '@/views/Statistics.vue';
-
-const router = new VueRouter({
-  mode: 'history',
-  routes: [
-    {
-      name: 'login',
-      path: '/login',
-      component: Login,
-    },
-    {
-      name: 'profile',
-      path: '/profile',
-      component: Profile,
-      meta: { auth: true },
-    },
-    {
-      name: 'routes',
-      path: '/routes',
-      component: Routes,
-      meta: { auth: true },
-    },
-    {
-      name: 'stats',
-      path: '/stats',
-      component: Statistics,
-      meta: { auth: true },
-    },
-    {
-      path: '*',
-      redirect: '/login',
-    },
-  ],
-});
+const router = new VueRouter({ mode: 'history', routes });
 
 router.beforeEach((to, from, next) => {
   getAuth().then(auth => {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,0 +1,41 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file contains app route data passed to VueRouter's constructor.
+// It lives in this file instead of index.ts so that unit tests can load it.
+
+import Login from '@/views/Login.vue';
+import Profile from '@/views/Profile.vue';
+import Routes from '@/views/Routes.vue';
+import Statistics from '@/views/Statistics.vue';
+
+export default [
+  {
+    name: 'login',
+    path: '/login',
+    component: Login,
+  },
+  {
+    name: 'profile',
+    path: '/profile',
+    component: Profile,
+    meta: { auth: true },
+  },
+  {
+    name: 'routes',
+    path: '/routes',
+    component: Routes,
+    meta: { auth: true },
+  },
+  {
+    name: 'stats',
+    path: '/stats',
+    component: Statistics,
+    meta: { auth: true },
+  },
+  {
+    path: '*',
+    redirect: '/login',
+  },
+];

--- a/src/testutil.ts
+++ b/src/testutil.ts
@@ -5,7 +5,18 @@
 // This file contains random junk. The only requirement for something being here
 // is that it's used by more than one testing-related file.
 
+import { Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+
 // Returns a deep copy of |data| (which must be serializable to JSON).
 export function deepCopy(data: any) {
   return JSON.parse(JSON.stringify(data));
+}
+
+// Returns the 'value' attribute from the Vuetify component wrapped by |w|.
+// TODO: Is there any way to avoid this 'as any' cast? I'm not
+// sure that there are TypeScript types for all Vuetify components:
+// https://github.com/vuetifyjs/vuetify/issues/5962
+export function getValue(w: Wrapper<Vue>): any {
+  return (w.vm as any).value;
 }

--- a/src/views/Profile.test.ts
+++ b/src/views/Profile.test.ts
@@ -14,7 +14,7 @@ import i18n from '@/plugins/i18n';
 import flushPromises from 'flush-promises';
 
 import { ClimbState, Team, User } from '@/models';
-import { deepCopy } from '@/testutil';
+import { deepCopy, getValue } from '@/testutil';
 import Profile from './Profile.vue';
 
 // Hardcoded test data to insert into Firestore.
@@ -91,14 +91,6 @@ describe('Profile', () => {
   // the element via a 'ref' attribute in the template.
   function findRef(ref: string): Wrapper<Vue> {
     return wrapper.find({ ref });
-  }
-
-  // Returns the 'value' attribute from the Vuetify component wrapped by |w|.
-  // TODO: Is there any way to avoid this 'as any' cast? I'm not
-  // sure that there are TypeScript types for all Vuetify components:
-  // https://github.com/vuetifyjs/vuetify/issues/5962
-  function getValue(w: Wrapper<Vue>): any {
-    return (w.vm as any).value;
   }
 
   // Validates the v-form component wrapped by |w|.

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -68,7 +68,7 @@
               </v-btn>
             </template>
 
-            <DialogCard title="Invite Code">
+            <DialogCard title="Invite code">
               <v-card-text>
                 <div class="invite-code mb-2">{{ teamDoc.invite }}</div>
                 <div>
@@ -100,7 +100,7 @@
               >
             </template>
 
-            <DialogCard title="Leave Team">
+            <DialogCard title="Leave team">
               <v-card-text>
                 Are you sure you want to leave your team?
               </v-card-text>
@@ -146,7 +146,7 @@
               >
             </template>
 
-            <DialogCard title="Join Team">
+            <DialogCard title="Join team">
               <v-card-text>
                 <div>
                   Ask your teammate to give you the {{ inviteCodeLength }}-digit
@@ -208,7 +208,7 @@
               >
             </template>
 
-            <DialogCard title="Create Team">
+            <DialogCard title="Create team">
               <v-card-text>
                 <div>
                   After creating a new team, you'll get an invite code to give


### PR DESCRIPTION
Display a confirmation dialog before signing the user out.
The "Sign out" item in the navigation drawer is easy to
accidentally click, and doing so is problematic when the
device doesn't have network connectivity. Also add a divider
between the other items and "Sign out" and write some tests.

Tangentially, switch the titles on dialogs displayed in the
Profile view to use sentence case instead of title case.
This is pretty arbitrary, but I think that "Sign Out" looks
funny and I'd like to be consistent.

Also add a "test:unit:only" script to package.json to make
it easier to run tests from a single file, e.g. "npm run
test:unit:only Toolbar".