### PR TITLE
Use Promise.resolve and Promise.reject.

### DIFF
--- a/src/log/index.ts
+++ b/src/log/index.ts
@@ -26,12 +26,14 @@ function getLogFunc(): LogFunc | Promise<LogFunc> {
     return getFunctions().then(functions => functions.httpsCallable('Log'));
   }
   if (isDev && devLogDest == LogDest.CONSOLE) {
-    return (data?: any) => {
-      console.log(data);
-      return new Promise(resolve => resolve({ data: {} }));
+    return data => {
+      for (const rec of data.records) {
+        console.log(`${rec.severity} ${rec.code}:`, rec.payload);
+      }
+      return Promise.resolve({ data: {} });
     };
   }
-  return () => new Promise(resolve => resolve({ data: {} }));
+  return () => Promise.resolve({ data: {} });
 }
 
 const defaultLogger = new Logger('log', getLogFunc());

--- a/src/log/logger.test.ts
+++ b/src/log/logger.test.ts
@@ -314,12 +314,7 @@ describe('Logger', () => {
 
   it('defers logging when passed a promise', done => {
     // Give the logger a promise for a log function.
-    createLogger(
-      5,
-      new Promise(resolve => {
-        resolve(endpoint.getLogFunc());
-      })
-    );
+    createLogger(5, Promise.resolve(endpoint.getLogFunc()));
 
     // Sending shouldn't be scheduled initially since the logger doesn't have a
     // log function yet (since it's still waiting on the promise).


### PR DESCRIPTION
Rewrite a bunch of calls like
"new Promise(resolve => { resolve('foo') })" to instead use
the shorter and clearer "Promise.resolve('foo')" for
returning an already-resolved promise with a given value.
Ditto with Promise.reject.

Also improve console logging output a bit.