### PR TITLE
Update Admin page to clear scores and delete empty teams.

### DIFF
--- a/go/admin/admin.go
+++ b/go/admin/admin.go
@@ -48,6 +48,10 @@ func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 
 		action := r.FormValue("action")
 		switch action {
+		case "clearScores":
+			handleClearScores(ctx, w, r, client)
+		case "emptyTeams":
+			handleEmptyTeams(ctx, w, r, client)
 		case "routes":
 			handlePostRoutes(ctx, w, r, client)
 		case "scores":
@@ -77,49 +81,83 @@ func checkPassword(ctx context.Context, client *firestore.Client, password strin
 const getHTML = `
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Admin</title>
-  <style>
-    body {
-      font-family: Arial, Helvetica, sans-serif;
-      font-size: 14px;
-    }
-    .input-row {
-      display: flex;
-      padding: 5px;
-      align-items: baseline;
-    }
-    .label {
-      min-width: 100px;
-    }
-  </style>
-</head>
-<body>
-  <form enctype="multipart/form-data" method="POST">
-    <h1>Admin</h1>
+  <head>
+    <title>Admin</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 14px;
+      }
+      .input-row {
+        display: flex;
+        padding: 5px;
+        align-items: baseline;
+      }
+      .label {
+        min-width: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <form enctype="multipart/form-data" method="POST">
+      <h1>Admin</h1>
 
-	<div class="input-row">
-      <span class="label">Password</span>
-      <input name="password" type="password" />
-    </div>
+      <p>A password must be supplied to perform any admin operations.</p>
+      <div class="input-row">
+        <span class="label">Password</span>
+        <input name="password" type="password" />
+      </div>
 
-    <h2>View scores</h2>
-    <div class="input-row">
-      <button name="action" value="scores" type="submit">View</button>
-    </div>
+      <h2>View scores</h2>
+      <p>View a scoreboard listing all teams.</p>
+      <div class="input-row">
+        <button name="action" value="scores" type="submit">View scores</button>
+      </div>
 
-    <h2>Update routes</h2>
-    <div class="input-row">
-      <span class="label">Areas CSV</span>
-      <input name="areas" type="file" accept=".csv" />
-    </div>
-    <div class="input-row">
-      <span class="label">Routes CSV</span>
-      <input name="routes" type="file" accept=".csv" />
-    </div>
-    <div class="input-row">
-      <button name="action" value="routes" type="submit">Upload</button>
-    </div>
-  </form>
-</body>
+      <h2>Update routes</h2>
+      <p>
+        Upload new area and route data in CSV format and use it to replace the
+        existing data.
+      </p>
+      <div class="input-row">
+        <span class="label">Areas CSV</span>
+        <input name="areas" type="file" accept=".csv" />
+      </div>
+      <div class="input-row">
+        <span class="label">Routes CSV</span>
+        <input name="routes" type="file" accept=".csv" />
+      </div>
+      <div class="input-row">
+        <button name="action" value="routes" type="submit">
+          Update routes
+        </button>
+      </div>
+
+      <h2>Delete empty teams</h2>
+      <p>Delete all teams that don't have any members.</p>
+      <div class="input-row">
+        <button name="action" value="emptyTeams" type="submit">
+          Delete empty teams
+        </button>
+      </div>
+
+      <h2>Clear scores</h2>
+      <p>Clear scores for all teams and users.</p>
+      <div class="input-row">
+        <span class="label">Confirm</span>
+        <input
+          name="confirm"
+          type="text"
+          autocomplete="off"
+          placeholder="Type 'REALLY CLEAR SCORES'"
+          style="min-width: 15em"
+        />
+      </div>
+      <div class="input-row">
+        <button name="action" value="clearScores" type="submit">
+          Clear scores
+        </button>
+      </div>
+    </form>
+  </body>
 </html>`

--- a/go/admin/clear_scores.go
+++ b/go/admin/clear_scores.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+)
+
+// handleClearScores handles an "clearScores" POST request.
+// It clears all scores from Cloud Firestore.
+func handleClearScores(ctx context.Context, w http.ResponseWriter, r *http.Request, client *firestore.Client) {
+	if r.FormValue("confirm") != "REALLY CLEAR SCORES" {
+		http.Error(w, "Didn't confirm that we really want to clear scores", http.StatusBadRequest)
+		return
+	}
+
+	// First, iterate over team documents.
+	it := client.Collection(teamCollectionPath).DocumentRefs(ctx)
+	for {
+		ref, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting team ref: %v", err), http.StatusInternalServerError)
+			return
+		}
+		var teamData team
+		if err := getDoc(ctx, ref, &teamData); err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting team doc: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Reset all of the "climbs" maps from the nested user data.
+		var updates []firestore.Update
+		for uid := range teamData.Users {
+			updates = append(updates, firestore.Update{
+				Path:  "users." + uid + ".climbs",
+				Value: map[string]climbState{},
+			})
+		}
+		if len(updates) > 0 {
+			log.Printf("Clearing scores from team doc %s (%+v)", ref.Path, teamData)
+			if _, err := ref.Update(ctx, updates); err != nil {
+				http.Error(w, fmt.Sprintf("Failed updating team: %v", err), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+
+	// Next, iterate over user documents.
+	it = client.Collection(userCollectionPath).DocumentRefs(ctx)
+	for {
+		ref, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting user ref: %v", err), http.StatusInternalServerError)
+			return
+		}
+		var userData user
+		if err := getDoc(ctx, ref, &userData); err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting user doc: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Clear the "climbs" map at the top level of the document.
+		var newClimbs interface{} = map[string]climbState{}
+		// If the user is on a team, we delete the map (since their climbs are
+		// stored in the team doc).
+		if userData.Team != "" {
+			newClimbs = firestore.Delete
+		}
+
+		log.Printf("Clearing score from user doc %s (%+v)", ref.Path, userData)
+		if _, err := ref.Update(ctx, []firestore.Update{{Path: "climbs", Value: newClimbs}}); err != nil {
+			http.Error(w, fmt.Sprintf("Failed updating user: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	fmt.Fprintln(w, "Cleared all scores")
+}

--- a/go/admin/empty_teams.go
+++ b/go/admin/empty_teams.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+)
+
+// handleEmptyTeams handles an "emptyTeams" POST request.
+// It deletes empty teams from Cloud Firestore.
+func handleEmptyTeams(ctx context.Context, w http.ResponseWriter, r *http.Request, client *firestore.Client) {
+	var deleted []team
+
+	it := client.Collection(teamCollectionPath).DocumentRefs(ctx)
+	for {
+		ref, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting team ref: %v", err), http.StatusInternalServerError)
+			return
+		}
+		var teamData team
+		if err := getDoc(ctx, ref, &teamData); err != nil {
+			http.Error(w, fmt.Sprintf("Failed getting team doc: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("Team %s (%q) has %d user(s)", ref.ID, teamData.Name, len(teamData.Users))
+		if len(teamData.Users) != 0 {
+			continue
+		}
+
+		log.Printf("Deleting %s (%+v)", ref.Path, teamData)
+		if _, err := ref.Delete(ctx); err != nil {
+			http.Error(w, fmt.Sprintf("Failed deleting team: %v", err), http.StatusInternalServerError)
+			return
+		}
+		deleted = append(deleted, teamData)
+	}
+
+	fmt.Fprintf(w, "Deleted %d empty team(s)\n", len(deleted))
+	for _, t := range deleted {
+		fmt.Fprintf(w, "%q\n", t.Name)
+	}
+}

--- a/go/admin/firestore.go
+++ b/go/admin/firestore.go
@@ -17,6 +17,7 @@ const (
 	indexedDataDocPath = "global/indexedData"
 	sortedDataDocPath  = "global/sortedData"
 	teamCollectionPath = "teams"
+	userCollectionPath = "users"
 )
 
 // getDoc fetches a snapshot of the document at ref and decodes it into out,
@@ -159,4 +160,15 @@ type team struct {
 		// Climbs contains a map from route ID (see route.ID) to state.
 		Climbs map[string]climbState `firestore:"climbs"`
 	} `firestore:"users"`
+}
+
+// user contains information about a user.
+// It correponds to documents in the collection at userCollectionPath.
+type user struct {
+	// Name contains the user's name.
+	Name string `firestore:"name"`
+	// Climbs contains the user's climbs. It's only used if the user isn't on a team.
+	Climbs map[string]climbState `firestore:"climbs"`
+	// Team contains the user's team ID. It's empty if they aren't on a team.
+	Team string `firestore:"team"`
 }


### PR DESCRIPTION
Update the page served by the Admin Cloud Function to
support clearing all scores and deleting teams that don't
have any members.

No unit tests, since Firestore provides zero test support
and no way to run locally, and writing a mock implementation
seems like it would be a lot of work without much benefit.