### PR TITLE
Add validation to Cloud Firestore security rules.

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,12 +1,46 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 rules_version = '2';
+
+// Documentation about this format:
+//   https://firebase.google.com/docs/database/security
+//   https://firebase.google.com/docs/rules
+//   https://firebase.google.com/docs/reference/rules/rules
+//
+// Basic stuff to keep in mind:
+// - resource.data is a Map containing the doc's data before an update.
+// - request.resource.data is a Map containing the doc's data after an update.
+// - getAfter() returns a Map containing a doc's data after the current
+//   transaction or batched write finishes.
+// - Field existence checks take this form:
+//     "key" in request.resource.data
+// - Null checks should only be used when checking non-document data like
+//   |request.auth|. I think.
+// - Be careful about quoting the left-hand operand to 'in':
+//     "uid" in doc: checks for a field named "uid"
+//     uid in doc:   checks for a field named after the value in variable |uid|
+
+// Returns true if the user is logged in.
+function loggedIn() {
+  return request.auth != null && request.auth.uid != null;
+}
+
+// Returns true if |name| is a valid user or team name.
+function nameValid(name) {
+  // The 50 here matches nameMaxLength in src/views/Profile.vue.
+  return name != "" && name.size() <= 50;
+}
+
+// Returns true if |code| is a properly-formatted team invitation code.
+function inviteCodeValid(code) {
+  // The 6 here matches inviteCodeLength in src/views/Profile.vue.
+  return code.size() == 6 && int(code) >= 0;
+}
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Returns true if the user is logged in.
-    function loggedIn() {
-      return request.auth != null && request.auth.uid != null;
-    }
-
     // Let anyone get /global/config.
     match /global/config {
       allow get: if true;
@@ -18,26 +52,133 @@ service cloud.firestore {
     }
 
     // Give users full access to their own docs.
-    // TODO: Validate fields here.
     match /users/{uid} {
-      allow get, write: if loggedIn() && request.auth.uid == uid;
+      // Returns true if |doc| contains valid data.
+      function userDocValid(doc) {
+        return "name" in doc && nameValid(doc.name);
+      }
+
+      // Returns true if |uid| will be listed in the doc for team ID |team|
+      // after the current transaction or batched write completes.
+      function teamHasUser(team) {
+        return uid in getAfter(
+            /databases/$(database)/documents/teams/$(team)).data.users;
+      }
+
+      // Returns true if |newDoc| contains valid team-related data.
+      // |oldDoc| should contain the previous version of the document.
+      function checkUserDocTeam(newDoc, oldDoc) {
+        return
+            ( // Valid cases for the team in the updated document:
+              // - User won't be on a team after update.
+              !("team" in newDoc) ||
+              // - User will be on the same team as before.
+              ("team" in oldDoc && newDoc.team == oldDoc.team) ||
+              // - New team, and user is listed in the new team's doc.
+              teamHasUser(newDoc.team)
+            ) &&
+            ( // Valid cases for the team in the original document:
+              // - User wasn't on a team before.
+              !("team" in oldDoc) ||
+              // - User didn't leave their team.
+              ("team" in newDoc && newDoc.team == oldDoc.team) ||
+              // - User left and is no longer listed in old team's doc.
+              !teamHasUser(oldDoc.team)
+            );
+      }
+
+      // Let the user get their own document.
+      allow get: if loggedIn() && request.auth.uid == uid;
+
+      // When the user is created, they shouldn't be on a team yet.
+      allow create:
+        if loggedIn() && request.auth.uid == uid &&
+            userDocValid(request.resource.data) &&
+            !("team" in request.resource.data);
+
+      // For updates, we additionally check the team field.
+      allow update:
+        if loggedIn() && request.auth.uid == uid &&
+            userDocValid(request.resource.data) &&
+            checkUserDocTeam(request.resource.data, resource.data);
     }
 
-    match /teams/{tid} {
-      // Let all logged-in users create new teams.
-      allow create: if loggedIn();
+    match /teams/{team} {
+      // Returns true if |doc| is a valid team doc.
+      // Also checks that |uid| is a member of the team and has valid data.
+      function teamDocValid(doc, uid) {
+        return "name" in doc && nameValid(doc.name) &&
+            "invite" in doc && inviteCodeValid(doc.invite) &&
+            "users" in doc && doc.users.size() <= 2 &&
+            uid in doc.users &&
+            "name" in doc.users[uid] && nameValid(doc.users[uid].name) &&
+            "climbs" in doc.users[uid];
+      }
 
-      // Let team members access their team, and let all logged-in
-      // users access update incomplete teams (to add themselves).
-      allow get, update:
+      // Users can only read docs describing their own teams or non-full teams.
+      allow get: if loggedIn() &&
+          (
+            request.auth.uid in resource.data.users ||
+            resource.data.users.size() < 2
+          );
+
+      // All logged-in users can create new teams.
+      allow create:
         if loggedIn() &&
-            (request.auth.uid in resource.data.users ||
-             resource.data.users.size() < 2);
+            teamDocValid(request.resource.data, request.auth.uid) &&
+            // User is only member of new team.
+            request.resource.data.users.size() == 1 &&
+            request.auth.uid in request.resource.data.users &&
+            // User and invite docs reference team.
+            getAfter(/databases/$(database)/documents/users/$(request.auth.uid)).data.team == team &&
+            getAfter(/databases/$(database)/documents/invites/$(request.resource.data.invite)).data.team == team;
+
+      // Users can add themselves to incomplete teams.
+      allow update:
+        if loggedIn() &&
+            teamDocValid(request.resource.data, request.auth.uid) &&
+            // Old team isn't full and doesn't contain user.
+            resource.data.users.size() < 2 &&
+            !(request.auth.uid in resource.data.users) &&
+            // New team has one more member and contains user.
+            request.resource.data.users.size() == resource.data.users.size() + 1 &&
+            request.auth.uid in request.resource.data.users &&
+            // User data is valid; other fields unchanged.
+            request.resource.data.name == resource.data.name &&
+            request.resource.data.invite == resource.data.invite &&
+            // User doc is updated to point at team.
+            getAfter(/databases/$(database)/documents/users/$(request.auth.uid)).data.team == team;
+
+      // Let users update their team docs as long as they don't change the users
+      // on the team or its invite code.
+      allow update:
+        if loggedIn() &&
+            teamDocValid(request.resource.data, request.auth.uid) &&
+            request.auth.uid in resource.data.users &&
+            request.resource.data.users.keys().hasOnly(resource.data.users.keys()) &&
+            request.resource.data.invite == resource.data.invite;
+
+      // Let users remove themselves from their team if they don't make any
+      // other changes to the doc.
+      allow update:
+        if loggedIn() && // skip teamDocValid() since it expects user on team
+            request.auth.uid in resource.data.users &&
+            !(request.auth.uid in request.resource.data.users) &&
+            request.resource.data.users.size() == resource.data.users.size() - 1 &&
+            request.resource.data.name == resource.data.name &&
+            request.resource.data.invite == resource.data.invite &&
+            // User doc updated not to reference team.
+            !("team" in getAfter(/databases/$(database)/documents/users/$(request.auth.uid)).data);
     }
 
-    match /invites/{iid} {
-      // Let all logged-in users create or read invites.
-      allow create, get: if loggedIn();
+    match /invites/{invite} {
+      // Let all logged-in users read or create invites. When creating a doc, it
+      // must point at a team that points back at the invite doc.
+      allow get: if loggedIn();
+      allow create: if loggedIn() &&
+        inviteCodeValid(invite) &&
+        "team" in request.resource.data &&
+        getAfter(/databases/$(database)/documents/teams/$(request.resource.data.team)).data.invite == invite;
     }
 
     // Access to everything else is denied by default.

--- a/firestore.test.ts
+++ b/firestore.test.ts
@@ -3,25 +3,39 @@
 // found in the LICENSE file.
 
 // This file contains tests for the Cloud Firestore security rules in the
-// firestore.rules file. It requires the Firestore emulator to be running:
-//   firebase setup:emulators:firestore
-//   firebase serve --only firestore
+// firestore.rules file. It requires the Firestore emulator to be set up using
+// "firebase setup:emulators:firestore".
+//
+// The emulator can be started using "firebase serve --only firestore", but "npm
+// run test:firetore" will do this automatically before executing the tests in
+// this file.
 //
 // More information about this junk:
 //   https://firebase.google.com/docs/firestore/security/test-rules-emulator
 //   https://github.com/firebase/quickstart-nodejs/tree/master/firestore-emulator/typescript-quickstart
 
 import * as firebase from '@firebase/testing';
-import * as fs from 'fs';
 
 const projectId = `firestore-test-${Date.now()}`;
+
+// Data to use in tests.
 const uid = 'test-uid';
+const team = 'team-id';
+const name = 'Test Name';
+const invite = '123456';
+const climbs = { route: 1 };
+const users = { [uid]: { name, climbs } };
 
 const authPath = 'global/auth';
 const configPath = 'global/config';
 const userPath = `users/${uid}`;
-const teamPath = 'teams/team-id';
-const invitePath = 'invites/123456';
+const teamPath = `teams/${team}`;
+const invitePath = `invites/${invite}`;
+
+const otherName = 'Other Name';
+const otherTeam = 'other-team-id';
+const otherInvite = '999999';
+const longName = 'a'.repeat(51); // exceeds limit in firestore.rules
 
 describe('Firestore', () => {
   // The admin app bypasses security rules and can be used for test setup.
@@ -32,8 +46,10 @@ describe('Firestore', () => {
   let anonDB: firebase.firestore.Firestore;
 
   beforeAll(async () => {
-    const rules = fs.readFileSync('./firestore.rules', 'utf8');
-    await firebase.loadFirestoreRules({ projectId, rules });
+    // package.json runs "firebase emulators:exec --only firestore", which
+    // automatically loads firestore.rules. If it didn't, we'd need to load the
+    // rules with fs.readFileSync() here and pass them to
+    // firebase.loadFirestoreRules().
 
     adminDB = firebase.initializeAdminApp({ projectId }).firestore();
     authDB = firebase
@@ -51,88 +67,350 @@ describe('Firestore', () => {
     await Promise.all(firebase.apps().map(app => app.delete()));
   });
 
+  // State describes documents to create for testing.
+  enum State {
+    // |uid| is the only member of |team|.
+    ON_TEAM,
+    // |team| exists without any members.
+    EMPTY_TEAM,
+    // No team doc is written.
+    NO_TEAM,
+  }
+
+  // Writes initial user, team, and invite documents as described by |state|.
+  async function writeDocs(state: State) {
+    await adminDB
+      .doc(userPath)
+      .set(state == State.ON_TEAM ? { name, team } : { name });
+
+    if (state == State.NO_TEAM) return;
+
+    await adminDB
+      .doc(teamPath)
+      .set({ name, invite, users: state == State.ON_TEAM ? users : {} });
+    await adminDB.doc(invitePath).set({ team });
+  }
+
+  // Define some aliases. Tests generally don't need to create docs before
+  // checking read access using allow(), since DocumentReference.get()
+  // returns an empty snapshot if the document doesn't exist (as long as the
+  // read isn't blocked by security rules).
+  const allow = firebase.assertSucceeds;
+  const deny = firebase.assertFails;
+
   it('denies access to auth doc', async () => {
-    await firebase.assertFails(authDB.doc(authPath).get());
-    await firebase.assertFails(authDB.doc(authPath).set({}));
+    const ref = authDB.doc(authPath);
+    await deny(ref.get());
+    await deny(ref.set({}));
+    await deny(ref.delete());
   });
 
-  it('allows anonymous read access to config doc', async () => {
-    await firebase.assertSucceeds(anonDB.doc(configPath).get());
-    await firebase.assertFails(anonDB.doc(configPath).set({}));
+  it('allows anonymous read-only access to config doc', async () => {
+    const ref = anonDB.doc(configPath);
+    await allow(ref.get());
+    await deny(ref.set({}));
+    await deny(ref.delete());
   });
 
-  it('allows signed-in read access to config doc', async () => {
-    await firebase.assertSucceeds(authDB.doc(configPath).get());
-    await firebase.assertFails(authDB.doc(configPath).set({}));
+  it('allows signed-in read-only access to config doc', async () => {
+    const ref = authDB.doc(configPath);
+    await allow(ref.get());
+    await deny(ref.set({}));
+    await deny(ref.delete());
   });
 
-  it('denies creating global doc', async () => {
-    await firebase.assertFails(authDB.doc('/global/foo').set({}));
+  it('denies creating or deleting other global docs', async () => {
+    const ref = authDB.doc('global/foo');
+    await deny(ref.set({}));
+    await deny(ref.delete());
   });
 
-  it('denies creating doc in new collection', async () => {
-    await firebase.assertFails(authDB.doc('/bogus/doc').set({}));
+  it('denies access to docs in new collections', async () => {
+    const ref = authDB.doc('bogus/doc');
+    await deny(ref.get());
+    await deny(ref.set({}));
+    await deny(ref.delete());
   });
 
-  it('allows read and write access to own user doc', async () => {
-    await firebase.assertSucceeds(authDB.doc(userPath).get());
-    await firebase.assertSucceeds(authDB.doc(userPath).set({}));
+  it('allows creating own user doc', async () => {
+    await allow(authDB.doc(userPath).set({ name }));
   });
 
-  it('denies access to other user doc', async () => {
-    const path = '/users/other-uid';
-    await firebase.assertFails(authDB.doc(path).get());
-    await firebase.assertFails(authDB.doc(path).set({}));
+  it('allows reading and updating own user doc', async () => {
+    await writeDocs(State.NO_TEAM);
+    const ref = authDB.doc(userPath);
+    await allow(ref.get());
+    await allow(ref.update({ name: otherName }));
+  });
+
+  it('denies deleting own user doc', async () => {
+    await deny(authDB.doc(userPath).delete());
+  });
+
+  it('denies access to other user docs', async () => {
+    const ref = authDB.doc('/users/other-uid');
+    await deny(ref.get());
+    await deny(ref.set({ name }));
+    await deny(ref.delete());
   });
 
   it('denies anonymous access to user docs', async () => {
-    await firebase.assertFails(anonDB.doc(userPath).get());
-    await firebase.assertFails(anonDB.doc(userPath).set({}));
+    const ref = anonDB.doc(userPath);
+    await deny(ref.get());
+    await deny(ref.set({ name }));
+    await deny(ref.delete());
+  });
+
+  it('performs basic validation of user doc fields', async () => {
+    const ref = authDB.doc(userPath);
+    await deny(ref.set({}));
+    await deny(ref.set({ name: '' }));
+    await deny(ref.set({ name: longName }));
+    // Team-related checks are tested separately.
   });
 
   it('denies enumerating user docs', async () => {
-    await firebase.assertFails(authDB.collectionGroup('users').get());
+    await deny(authDB.collectionGroup('users').get());
   });
 
-  it('allows creating team doc', async () => {
-    const data = { users: { [uid]: {} } };
-    await firebase.assertSucceeds(authDB.doc(teamPath).set(data));
+  it('allows read and update access to own team doc', async () => {
+    await writeDocs(State.ON_TEAM);
+    const ref = authDB.doc(teamPath);
+    await allow(ref.get());
+    await allow(ref.update({ name: otherName }));
+    await deny(ref.delete());
   });
 
-  it('allows read and write access to own team doc', async () => {
-    const data = { users: { [uid]: {}, 'other-uid': {} } };
-    await adminDB.doc(teamPath).set(data);
-    await firebase.assertSucceeds(authDB.doc(teamPath).get());
-    await firebase.assertSucceeds(authDB.doc(teamPath).set(data));
+  it('denies updating invite code in team doc', async () => {
+    await writeDocs(State.ON_TEAM);
+    await deny(authDB.doc(teamPath).update({ invite: otherInvite }));
   });
 
-  it('allows read and write access to other incomplete team doc', async () => {
-    const data = { users: { 'other-uid': {} } };
-    await adminDB.doc(teamPath).set(data);
-    await firebase.assertSucceeds(authDB.doc(teamPath).get());
-    await firebase.assertSucceeds(authDB.doc(teamPath).set(data));
+  it('allows read access to other incomplete team doc', async () => {
+    await writeDocs(State.NO_TEAM);
+    await adminDB
+      .doc(teamPath)
+      .set({ name, invite, users: { 'other-uid': {} } });
+
+    const ref = authDB.doc(teamPath);
+    await allow(ref.get());
+    await deny(ref.update({ name: name + ' Foo' }));
+    await deny(ref.delete());
   });
 
-  it('denies read and write access to other complete team doc', async () => {
-    const data = { users: { a: {}, b: {} } };
-    await adminDB.doc(teamPath).set(data);
-    await firebase.assertFails(authDB.doc(teamPath).get());
-    await firebase.assertFails(authDB.doc(teamPath).set(data));
+  it('denies read and write access to other full team doc', async () => {
+    await writeDocs(State.NO_TEAM);
+    await adminDB.doc(teamPath).set({ name, invite, users: { a: {}, b: {} } });
+
+    const ref = authDB.doc(teamPath);
+    await deny(ref.get());
+    await deny(ref.update({ name: name + ' Foo' }));
+    await deny(ref.delete());
+  });
+
+  it('validates team docs on create', async () => {
+    await adminDB.doc(userPath).set({ name, team });
+    await adminDB.doc(invitePath).set({ invite });
+    const ref = authDB.doc(teamPath);
+
+    await deny(ref.set({})); // empty doc
+
+    // Bad names.
+    await deny(ref.set({ invite, users }));
+    await deny(ref.set({ name: '', invite, users }));
+    await deny(ref.set({ name: longName, invite, users }));
+
+    // Bad invite codes.
+    await deny(ref.set({ name, users }));
+    await deny(ref.set({ name, invite: '', users }));
+    await deny(ref.set({ name, invite: '1234567', users }));
+    await deny(ref.set({ name, invite: 'abcdef', users }));
+
+    // We should be the only user on the new team.
+    await deny(ref.set({ name, invite, users: {} }));
+    await deny(ref.set({ name, invite, users: { other: {} } }));
+    await deny(ref.set({ name, invite, users: { [uid]: {}, second: {} } }));
+  });
+
+  it('validates team docs on update', async () => {
+    await writeDocs(State.ON_TEAM);
+    const ref = authDB.doc(teamPath);
+    await deny(ref.update({ name: '' }));
+    await deny(ref.update({ invite: otherInvite }));
+    await deny(ref.update({ users: { [uid]: {}, second: {}, third: {} } }));
   });
 
   it('denies enumerating team docs', async () => {
-    await firebase.assertFails(authDB.collectionGroup('teams').get());
+    await deny(authDB.collectionGroup('teams').get());
   });
 
-  it('allows reading and creating invite doc', async () => {
-    await firebase.assertSucceeds(authDB.doc(invitePath).get());
-    await firebase.assertSucceeds(authDB.doc(invitePath).set({}));
+  it('allows reading invite docs', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await allow(authDB.doc(invitePath).get());
+  });
 
-    // Updates to the now-existing doc should be blocked.
-    await firebase.assertFails(authDB.doc(invitePath).set({}));
+  it('denies updating invite docs', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await deny(authDB.doc(invitePath).set({ team }));
+    await deny(authDB.doc(invitePath).delete());
   });
 
   it('denies enumerating invite docs', async () => {
-    await firebase.assertFails(authDB.collectionGroup('invites').get());
+    await deny(authDB.collectionGroup('invites').get());
+  });
+
+  it('allows creating team', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite, users });
+    batch.set(authDB.doc(invitePath), { team });
+    await allow(batch.commit());
+  });
+
+  it('denies creating team without updating user doc', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.set(authDB.doc(teamPath), { name, invite, users });
+    batch.set(authDB.doc(invitePath), { team });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team when user doc has other team', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team: otherTeam });
+    batch.set(authDB.doc(teamPath), { name, invite, users });
+    batch.set(authDB.doc(invitePath), { team });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team without adding user', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite, users: {} });
+    batch.set(authDB.doc(invitePath), { team });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team without creating invite doc', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite, users });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team when team doc has other invite', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite: otherInvite, users });
+    batch.set(authDB.doc(invitePath), { team });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team when invite doc has other team', async () => {
+    await writeDocs(State.NO_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite, users });
+    batch.set(authDB.doc(invitePath), { team: otherTeam });
+    await deny(batch.commit());
+  });
+
+  it('denies creating team with invalid invite code', async () => {
+    await writeDocs(State.NO_TEAM);
+    const badInvite = '1234567'; // too long
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.set(authDB.doc(teamPath), { name, invite: badInvite, users });
+    batch.set(authDB.doc(`invites/${badInvite}`), { team });
+    await deny(batch.commit());
+  });
+
+  it('denies creating invite doc without team', async () => {
+    await deny(authDB.doc(invitePath).set({ team }));
+  });
+
+  it('allows joining empty team', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.update(authDB.doc(teamPath), { users });
+    await allow(batch.commit());
+  });
+
+  it('allows joining non-full team', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await adminDB.doc(teamPath).update({ users: { a: {} } });
+
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.update(authDB.doc(teamPath), { ['users.' + uid]: { name, climbs } });
+    await allow(batch.commit());
+  });
+
+  it('denies joining full team', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await adminDB.doc(teamPath).update({ users: { a: {}, b: {} } });
+
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.update(authDB.doc(teamPath), { ['users.' + uid]: { name, climbs } });
+    await deny(batch.commit());
+  });
+
+  it('denies joining team without updating team doc', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await deny(authDB.doc(userPath).update({ team }));
+  });
+
+  it('denies joining team without updating user doc', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    await deny(authDB.doc(teamPath).update({ users }));
+  });
+
+  it('denies joining team when user doc points at other team', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team: otherTeam });
+    batch.update(authDB.doc(teamPath), { users });
+    await deny(batch.commit());
+  });
+
+  it('denies joining team with other UID in team doc', async () => {
+    await writeDocs(State.EMPTY_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), { team });
+    batch.update(authDB.doc(teamPath), { users: { a: { name, climbs } } });
+    await deny(batch.commit());
+  });
+
+  it('allows leaving team', async () => {
+    await writeDocs(State.ON_TEAM);
+    const batch = authDB.batch();
+    batch.update(authDB.doc(userPath), {
+      team: firebase.firestore.FieldValue.delete(),
+    });
+    batch.update(authDB.doc(teamPath), {
+      ['users.' + uid]: firebase.firestore.FieldValue.delete(),
+    });
+    await allow(batch.commit());
+  });
+
+  it('denies leaving team without updating user doc', async () => {
+    await writeDocs(State.ON_TEAM);
+    await deny(authDB.doc(teamPath).update({ users: {} }));
+  });
+
+  it('denies leaving team without updating team doc', async () => {
+    await writeDocs(State.ON_TEAM);
+    await deny(
+      authDB.doc(userPath).update({
+        team: firebase.firestore.FieldValue.delete(),
+      })
+    );
   });
 });

--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -8,7 +8,7 @@
 // Loads the core Firebase library asynchronously.
 // Outside code should only call this if it needs access to Firebase's weird
 // constant values, e.g. firebase.auth.GoogleAuthProvider or
-// firebase.firestore.FieldValue.Delete().
+// firebase.firestore.FieldValue.delete().
 export function getFirebase() {
   return import(/* webpackChunkName: "firebase-app" */ 'firebase/app');
 }


### PR DESCRIPTION
Update firestore.rules to validate documents written by
users, and add additional unit tests that verify the rules.
The rules perform fairly-extensive consistency checks
between user, team, and invite docs.

The updated rules are complicated, but there are also a lot
of tests now. I manually verified that the general flows of
signing in for the first time and creating, leaving, and
joining a team seems to still work after pushing these rules
to the dev instance.

Also update firestore.test.ts to not bother applying rules,
since they already appear to be loaded automatically by the
emulator.