### PR TITLE
Use fallback display name for email login.

### DIFF
--- a/src/firebase/mock.ts
+++ b/src/firebase/mock.ts
@@ -151,7 +151,7 @@ class MockWriteBatch {
 
 // Stub implementation of firebase.auth.User.
 export class MockUser {
-  constructor(public uid: string, public displayName: string) {}
+  constructor(public uid: string, public displayName: string | null) {}
   getIdToken() {
     return Promise.resolve('token');
   }

--- a/src/views/Login.test.ts
+++ b/src/views/Login.test.ts
@@ -83,6 +83,23 @@ describe('Login', () => {
     expect(wrapper.vm.$route.name).toBe('profile');
   });
 
+  it('uses default name if display name is unset', async () => {
+    // Simulate the display name being unset, which happens during email signin.
+    const user = MockFirebase.currentUser!;
+    user.displayName = null;
+    MockAuthUI.pendingRedirect = true;
+    await flushPromises();
+
+    MockAuthUI.config!.callbacks!.signInSuccessWithAuthResult!();
+    await flushPromises();
+
+    // The Firestore rules don't permit missing names, so the view should use a
+    // fallback.
+    expect(MockFirebase.getDoc(`users/${user.uid}`)).toEqual({
+      name: 'Unknown Climber',
+    });
+  });
+
   it('goes to routes view after subsequent logins', async () => {
     MockAuthUI.pendingRedirect = true;
     await flushPromises();

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -31,7 +31,7 @@
 <script lang="ts">
 import { Component, Mixins, Watch } from 'vue-property-decorator';
 
-import { logInfo } from '@/log';
+import { logError, logInfo } from '@/log';
 import { getAuth, getFirebase, getFirebaseUI, getFirestore } from '@/firebase';
 
 import Card from '@/components/Card.vue';
@@ -77,13 +77,19 @@ export default class Login extends Mixins(Perf) {
                     // view.
                     this.$router.replace('routes');
                   } else {
-                    // Otherwise, create the doc using their default name and send
-                    // them to the profile view.
-                    logInfo('create_user', { name: user.displayName });
+                    // Otherwise, create the doc using their display name and
+                    // send them to the profile view. Note that the name is null
+                    // when using the email provider.
+                    const name = user.displayName || 'Unknown Climber';
+                    logInfo('create_user', { name });
                     ref
-                      .set({ name: user.displayName }, { merge: true })
+                      .set({ name }, { merge: true })
                       .then(() => {
                         this.$router.replace('profile');
+                      })
+                      .catch(err => {
+                        this.$emit('error-msg', `Failed creating user: ${err}`);
+                        logError('create_user_failed', err);
                       });
                   }
                 });


### PR DESCRIPTION
Email signin was broken by a recent Firestore validation
change that required that user docs contain names -- no
display name is supplied when signing in via email, so we
now fall back to 'Unknown Climber' in that case.