### PR TITLE
Rename .env to .env.example.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# This file contains default environment variable values.
-# These variables should be overridden by a .env.local file
-# that isn't checked into source control.
+# This file contains example environment variable values.
+# It should be used as a template for creating a .env file that isn't checked
+# into source control.
 #
 # Site-specific assets can be stored in the public/assets directory, which will
 # be accessible at /assets in the deployed site and which is listed in

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 node_modules/
 
 # Site configuration and assets.
-.env.local
+.env
 .firebaserc
 public/assets
 


### PR DESCRIPTION
Rename the existing placeholder .env file to .env.example,
and make .env get ignored by git. We should switch to using
.env for per-site configuration since .env.local isn't
loaded in all cases (e.g. Nightwatch seems to only look at
.env), and the dotenv package doesn't allow overriding
existing values by manually loading .env.local.