### PR TITLE
Visual improvements to login view.

### DIFF
--- a/src/firebase/mock.ts
+++ b/src/firebase/mock.ts
@@ -294,12 +294,9 @@ jest.mock('firebase/app', () => {
   };
 
   // Set some random const properties on the auth method.
-  (app.auth as any).EmailAuthProvider = {
-    PROVIDER_ID: MockEmailAuthProviderID,
-  };
-  (app.auth as any).GoogleAuthProvider = {
-    PROVIDER_ID: MockGoogleAuthProviderID,
-  };
+  const authAny = app.auth as any;
+  authAny.EmailAuthProvider = { PROVIDER_ID: MockEmailAuthProviderID };
+  authAny.GoogleAuthProvider = { PROVIDER_ID: MockGoogleAuthProviderID };
 
   return app;
 });
@@ -348,6 +345,9 @@ jest.mock('firebaseui', () => {
       AuthUI: {
         // Pretend like an instance has already been created.
         getInstance: () => MockAuthUI,
+      },
+      CredentialHelper: {
+        NONE: {},
       },
     },
   };


### PR DESCRIPTION
- Remove the card around the FirebaseUI auth element, since
  the email auth widget is itself rendered in a card on
  large displays.
- Give the view a white background so the email auth widget
  looks okay on mobile.
- Disable the account chooser (only used for email auth)
  since it's ugly and doesn't seem to work right.
- Display the spinner while we're creating the user doc
  after email auth, since there's no redirect and the UI
  hence isn't already hidden by the existing logic for
  OAuth.