### PR TITLE
Make Profile view search for unused invite codes.

### DIFF
--- a/src/views/Routes.test.ts
+++ b/src/views/Routes.test.ts
@@ -119,8 +119,7 @@ describe('Routes', () => {
     expected.users[otherUID].climbs = {};
 
     // The team doc in Firestore should be updated.
-    const teamData: Partial<Team> = MockFirebase.getDoc(`teams/${teamID}`);
-    expect(teamData).toEqual(expected);
+    expect(MockFirebase.getDoc(`teams/${teamID}`)).toEqual(expected);
 
     // Check that one of the RouteLists also got the updated climb states.
     expect(

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -134,7 +134,7 @@ export default class Routes extends Mixins(Perf, UserLoader) {
           }
         },
         err => {
-          this.$emit('error-msg', `Failed loading route data: {err}`);
+          this.$emit('error-msg', `Failed loading route data: ${err}`);
           logError('routes_load_sorted_data_failed', err);
         }
       );


### PR DESCRIPTION
When creating a team, try to find an unused invite code up
to ten times before failing. Before, we'd just try to insert
a document for the new code without checking it first. The
Firestore security rules should reject collisions, but it
seems nicer to handle them gracefully by retrying.

If my math is right, the previously probability of a
collision with 100 existing teams was just 0.0001, but why
not reduce that to 1e-40?

Also fix some broken interpolated error messages.