### PR TITLE
Run Firestore emulator on port 8085.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,9 +3,7 @@
     {
       "target": "prod",
       "public": "dist",
-      "ignore": [
-        "report.html"
-      ],
+      "ignore": ["report.html"],
       "rewrites": [
         {
           "source": "**",
@@ -20,5 +18,10 @@
   },
   "storage": {
     "rules": "storage.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": "8085"
+    }
   }
 }


### PR DESCRIPTION
Run the Firestore emulator used by "npm run test:firestore"
on a different port. By default it uses port 8080, which
conflicts with "npm run serve".