### PR TITLE
Make miscellaneous improvements to logging.

### DIFF
--- a/e2e/tests/test.ts
+++ b/e2e/tests/test.ts
@@ -132,6 +132,7 @@ module.exports = {
 
     browser
       .getLog('browser', entries => {
+        console.log('\nBrowser console:');
         for (const entry of entries) {
           // Log entry messages start with URLs like this (but much longer):
           //
@@ -139,11 +140,22 @@ module.exports = {
           //
           // We chop off everything before the last path in the list and then
           // remove its leading './' and query string.
-          const msg = entry.message
+          let msg = entry.message
             .replace(/^webpack-internal:\/\/\//, '')
             .replace(/^(\S+!)/, '')
             .replace(/^\.\//, '')
             .replace(/^([^?]+)\?\S+/, '$1');
+
+          // After the path and a line:column like "55:18", there appears to be
+          // a JSON string containing the actual message. Try to unescape it so
+          // we don't write a bunch of annoying backslash-escaped double quotes.
+          try {
+            const match = msg.match(/^\S+ \S+ /);
+            if (match) {
+              const prefix = match[0];
+              msg = prefix + JSON.parse(msg.substr(prefix.length));
+            }
+          } catch {}
 
           console.log(`[${entry.level}] ${entry.timestamp}: ${msg}`);
         }

--- a/src/log/index.ts
+++ b/src/log/index.ts
@@ -40,7 +40,12 @@ function getLogFunc(): LogFunc | Promise<LogFunc> {
   return () => Promise.resolve({ data: {} });
 }
 
-const defaultLogger = new Logger('log', getLogFunc());
+const defaultLogger = new Logger(
+  'log',
+  getLogFunc(),
+  // If logging to the console, do so immediately to help with debugging.
+  isDev && devLogDest == LogDest.CONSOLE ? 0 : 10_000
+);
 
 // Helper function that sends a log message to Stackdriver.
 // See the Logger class's log method for more details.

--- a/src/log/logger.test.ts
+++ b/src/log/logger.test.ts
@@ -329,4 +329,20 @@ describe('Logger', () => {
       done();
     });
   });
+
+  it('supports synchronous logging', done => {
+    createLogger(0);
+    const rec = newRecord(now, 'code');
+    sendRecord(rec);
+
+    // The logger should've already sent the record. This also guards against a
+    // regression of a bug where _claimAbandonedRecords() would actually claim
+    // the logger's own queued records.
+    expect(logger.isSendScheduled()).toBe(false);
+    endpoint.handleCall(true).then(data => {
+      expect(data).toEqual(new CloudFuncData(now, [rec]));
+      expect(logger.isSendScheduled()).toBe(false);
+      done();
+    });
+  });
 });

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -72,7 +72,7 @@ export class Logger {
   constructor(
     name: string,
     logFunc: LogFunc | Promise<LogFunc>,
-    intervalMs = 10_000,
+    intervalMs: number,
     nowFunc = () => new Date().getTime(),
     onlineFunc = () => navigator.onLine
   ) {
@@ -256,8 +256,9 @@ export class Logger {
     Object.keys(localStorage).forEach(key => {
       // Look for other instances' last-active times.
       if (
-        !key.startsWith(this._name + '.') ||
-        !key.endsWith('.' + lastActiveKeySuffix)
+        !key.startsWith(`${this._name}.`) ||
+        !key.endsWith(`.${lastActiveKeySuffix}`) ||
+        key.startsWith(this._storagePrefix) // skip our own records
       ) {
         return;
       }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -9,7 +9,7 @@
     <v-container
       class="container"
       ref="container"
-      v-show="ready"
+      v-show="showUI"
       grid-list-md
       text-ms-center
     >
@@ -23,12 +23,12 @@
         <div id="firebaseui-auth-container"></div>
       </v-layout>
     </v-container>
-    <Spinner v-if="!ready" />
+    <Spinner v-if="!showUI" />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Watch } from 'vue-property-decorator';
+import { Component, Mixins } from 'vue-property-decorator';
 
 import { logError, logInfo } from '@/log';
 import { getAuth, getFirebase, getFirebaseUI, getFirestore } from '@/firebase';
@@ -52,7 +52,7 @@ export default class Login extends Mixins(Perf) {
   // checking/creating the user doc in Firestore).
   completingLogin = false;
 
-  get ready() {
+  get showUI() {
     // Hide the login elements when we don't need anything else from the user.
     return !this.pendingRedirect && !this.completingLogin;
   }
@@ -65,6 +65,7 @@ export default class Login extends Mixins(Perf) {
         if (!ui) ui = new firebaseui.auth.AuthUI(auth);
 
         this.pendingRedirect = ui.isPendingRedirect();
+        if (!this.pendingRedirect) this.logReady('login_loaded');
 
         ui.start('#firebaseui-auth-container', {
           // Disable the account chooser, which is ugly and doesn't seem to work
@@ -116,11 +117,6 @@ export default class Login extends Mixins(Perf) {
         });
       }
     );
-  }
-
-  @Watch('ready')
-  onReady(val: boolean) {
-    if (val) this.logReady('login_loaded');
   }
 }
 </script>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -579,14 +579,14 @@ export default class Profile extends Mixins(Perf, UserLoader) {
     if (this.leavingTeam) throw new Error('Already leaving team');
     this.leavingTeam = true;
 
-    logInfo('leave_team', {});
-
     // Grab this before leaving so we can use it in a message later.
     const teamName = this.teamDoc.name;
 
     new Promise(resolve => {
       if (!this.userRef) throw new Error('No user ref');
       if (!this.teamRef) throw new Error('No team ref');
+
+      logInfo('leave_team', { team: this.teamRef.id });
 
       // Grab the user's climbs from the team doc.
       const uid = this.user.uid;


### PR DESCRIPTION
- Remove extra quoting around E2E test console messages.
- Write log messages to the console immediately instead of
  batching them.
- Fix a subtle bug where Logger could claim its own queued
  logs, which would result in them not getting sent when
  they should.
- Fix an issue in the Login view where 'login_loaded' was
  never logged, due to the 'ready' variable initially
  starting out true. Renamed the variable to 'showUI', which
  is more accurate.
- Make the Profile view's 'leave_team' message include the
  team ID.