### PR TITLE
Include area IDs in global/sortedData.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Heterogeneous singleton documents:
                 route.
 *   `sortedData` - Document containing sorted area and route information:
     *   `areas` - Array of sorted area maps:
+        *   `id` - String field containing area ID, e.g. `my_area`.
         *   `name` - String field containing area name, e.g. `My Area`.
         *   `routes` - Array of sorted route maps:
             *   `id` - String containing the unique route ID. This should be a

--- a/go/admin/routes_test.go
+++ b/go/admin/routes_test.go
@@ -77,9 +77,8 @@ func TestNewSortedData(t *testing.T) {
 	r2 := db.Route{ID: "r2", Name: "R2", Area: "a1", Grade: "5.9", Lead: 12, TR: 6}
 	r3 := db.Route{ID: "r3", Name: "R3", Area: "a2", Grade: "5.10a", Lead: 16, TR: 8}
 
-	// makeArea returns a copy of a with its ID field cleared and rs assigned to its Routes field.
+	// makeArea returns a copy of a with rs assigned to its Routes field.
 	makeArea := func(a db.Area, rs ...db.Route) db.Area {
-		a.ID = ""
 		for _, r := range rs {
 			r.Area = ""
 			a.Routes = append(a.Routes, r)

--- a/go/db/firestore.go
+++ b/go/db/firestore.go
@@ -43,7 +43,6 @@ func GetDoc(ctx context.Context, ref *firestore.DocumentRef, out interface{}) er
 type SortedData struct {
 	// Areas contains areas in the order in which they were seen.
 	// Each area's Routes field contains routes in the order in which they were seen.
-	// The area.ID field is unset.
 	Areas []Area `firestore:"areas"`
 }
 
@@ -59,7 +58,7 @@ func NewSortedData(areas []Area, routes []Route) (SortedData, error) {
 		areaRoutes[id] = append(areaRoutes[id], r)
 	}
 
-	// Copy areas, assign routes, and clear area IDs.
+	// Copy areas and assign routes.
 	sd := SortedData{Areas: make([]Area, len(areas))}
 	copy(sd.Areas, areas)
 	for i := range sd.Areas {
@@ -68,7 +67,6 @@ func NewSortedData(areas []Area, routes []Route) (SortedData, error) {
 			return SortedData{}, fmt.Errorf("no routes defined for area %q", id)
 		}
 		sd.Areas[i].Routes = areaRoutes[id]
-		sd.Areas[i].ID = ""
 		delete(areaRoutes, id)
 	}
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -46,19 +46,20 @@ export class SetClimbStateEvent {
 }
 
 // Area contains information about a climbing area.
-// It appears in the global/indexedData and global/SortedData Firestore docs.
+// It appears in the global/indexedData and global/sortedData Firestore docs.
 export interface Area {
+  id?: string; // only in sortedData
   name: string;
-  routes?: Route[];
+  routes?: Route[]; // only in sortedData
 }
 
 // Route contains information about a climbing route.
-// It appears in the global/indexedData and global/SortedData Firestore docs.
+// It appears in the global/indexedData and global/sortedData Firestore docs.
 export interface Route {
-  id?: string;
+  id?: string; // only in sortedData
   name: string;
   grade: string;
-  area?: string;
+  area?: string; // only in indexedData
   lead: number;
   tr: number;
 }
@@ -91,6 +92,6 @@ export interface TeamUserData {
 // User represents a document in the 'users' collection.
 export interface User {
   name: string;
-  team?: string;
-  climbs?: Record<string, ClimbState>;
+  team?: string; // only if on a team
+  climbs?: Record<string, ClimbState>; // only if not on a team
 }

--- a/src/views/Routes.test.ts
+++ b/src/views/Routes.test.ts
@@ -33,6 +33,7 @@ const sortedData: SortedData = {
   areas: [
     {
       name: 'Area 1',
+      id: 'a1',
       routes: [
         { id: 'r1', name: 'Route 1', grade: '5.10a', lead: 10, tr: 5 },
         { id: 'r2', name: 'Route 2', grade: '5.7', lead: 6, tr: 3 },
@@ -40,6 +41,7 @@ const sortedData: SortedData = {
     },
     {
       name: 'Area 2',
+      id: 'a2',
       routes: [{ id: 'r3', name: 'Route 3', grade: '5.12c', lead: 20, tr: 10 }],
     },
   ],

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -4,10 +4,7 @@
 
 <template>
   <v-expansion-panel v-if="ready" expand>
-    <v-expansion-panel-content
-      v-for="area in sortedData.areas"
-      :key="area.name"
-    >
+    <v-expansion-panel-content v-for="area in sortedData.areas" :key="area.id">
       <template v-slot:header>
         <div class="area">{{ area.name }}</div>
       </template>


### PR DESCRIPTION
Update the Admin Cloud Function to include area IDs when
writing the global/sortedData Firestore doc. I'd initially
left this out since we don't need it when displaying routes,
but it'd actually be useful to use as a v-for key and during
end-to-end testing.