### PR TITLE
Prevent replacing team member after they report climbs.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,9 +56,11 @@ VUE_APP_FIREBASE_APP_ID=
 #
 # End-to-end tests will use E2E_URL's Firebase configuration, which typically
 # means that they'll be hitting the live Firebase Authentication and Cloud
-# Firestore instances. The account specified here should be created with email
+# Firestore instances. The accounts specified here should be created with email
 # authentication using the Firebase Console.
 E2E_URL=http://localhost:8080/
-E2E_EMAIL=
-E2E_PASSWORD=
 E2E_TEST_FUNC_URL=
+E2E_FIRST_EMAIL=
+E2E_FIRST_PASSWORD=
+E2E_SECOND_EMAIL=
+E2E_SECOND_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -79,15 +79,11 @@ Heterogeneous singleton documents:
             *   `climbs` - Map field containing information about the user's
                 completed climbs. Keys are route IDs. Values are 0 for not
                 climbed, 1 for lead, or 2 for top-rope.
+            *   `left`: Boolean field set to true if the user has left the team.
 
 ### `users` collection
 
 *   `<uid>` - Document containing information about a user.
     *   `name` - String field containing the user's name, e.g. "Some Climber".
-    *   `climbs` - Map field containing information about completed climbs. Keys
-        are route IDs. Values are 0 for not climbed, 1 for lead, or 2 for
-        top-rope. Climbs are only stored here when the user is not on a team:
-        when joining a team, climbs are stored in the `teams` doc, and when
-        leaving a team, climbs are moved back to the `users` doc.
     *   `team` - String field containing ID of a document in the `teams`
         collection. Unset if the user is not on a team.

--- a/e2e/globals.ts
+++ b/e2e/globals.ts
@@ -8,19 +8,19 @@ const querystring = require('querystring');
 // Global hooks can be defined here.
 module.exports = {
   before: async () => {
-    if (!process.env.E2E_EMAIL) throw new Error('E2E_EMAIL undefined');
-    console.log(`Deleting user ${process.env.E2E_EMAIL}`);
+    for (const varName of ['E2E_EMAIL_1', 'E2E_EMAIL_2']) {
+      const email = process.env[varName];
+      if (!email) throw new Error(`${varName} undefined`);
+      console.log(`Deleting user ${email}`);
 
-    // Axios sends JSON-encoded form parameters by default, but Go expects
-    // URL-encoded params. See
-    // https://github.com/axios/axios#using-applicationx-www-form-urlencoded-format.
-    await axios.post(
-      process.env.E2E_TEST_FUNC_URL,
-      querystring.stringify({
-        action: 'deleteUser',
-        email: process.env.E2E_EMAIL,
-      })
-    );
+      // Axios sends JSON-encoded form parameters by default, but Go expects
+      // URL-encoded params. See
+      // https://github.com/axios/axios#using-applicationx-www-form-urlencoded-format.
+      await axios.post(
+        process.env.E2E_TEST_FUNC_URL,
+        querystring.stringify({ action: 'deleteUser', email })
+      );
+    }
   },
 
   afterEach: (browser, done) => {

--- a/e2e/pages/profile.ts
+++ b/e2e/pages/profile.ts
@@ -64,9 +64,12 @@ module.exports = {
         .click('@inviteDismissButton');
     },
     checkUserOnTeam(userName: string, teamName: string) {
-      return this.waitForElementVisible('@teamNameField')
-        .assert.value('@teamNameField', teamName)
-        .assert.containsText('@teamMemberDiv', userName);
+      return this.waitForElementVisible('@teamNameField').assert.value(
+        '@teamNameField',
+        teamName
+      );
+      this.expect.element('@teamMemberDiv').text.to.contain(userName);
+      return this;
     },
     // setValue() doesn't clear the existing value in a v-text-field, and
     // clearValue() doesn't seem to work either, so use this garbage instead.

--- a/firestore.rules
+++ b/firestore.rules
@@ -58,11 +58,15 @@ service cloud.firestore {
         return "name" in doc && nameValid(doc.name);
       }
 
-      // Returns true if |uid| will be listed in the doc for team ID |team|
-      // after the current transaction or batched write completes.
-      function teamHasUser(team) {
-        return uid in getAfter(
-            /databases/$(database)/documents/teams/$(team)).data.users;
+      // Returns true if |uid| is listed as an active member in |teamDoc|.
+      // This returns false if the user is marked as being an inactive member of
+      // the team (i.e. they left the team after reporting climbs).
+      function teamHasUser(teamDoc) {
+        return uid in teamDoc.data.users &&
+            (
+              !("left" in teamDoc.data.users[uid]) ||
+              !teamDoc.data.users[uid].left
+            );
       }
 
       // Returns true if |newDoc| contains valid team-related data.
@@ -75,15 +79,15 @@ service cloud.firestore {
               // - User will be on the same team as before.
               ("team" in oldDoc && newDoc.team == oldDoc.team) ||
               // - New team, and user is listed in the new team's doc.
-              teamHasUser(newDoc.team)
+              teamHasUser(getAfter(/databases/$(database)/documents/teams/$(newDoc.team)))
             ) &&
             ( // Valid cases for the team in the original document:
               // - User wasn't on a team before.
               !("team" in oldDoc) ||
               // - User didn't leave their team.
               ("team" in newDoc && newDoc.team == oldDoc.team) ||
-              // - User left and is no longer listed in old team's doc.
-              !teamHasUser(oldDoc.team)
+              // - User left and is no longer listed as active in old team's doc.
+              !teamHasUser(getAfter(/databases/$(database)/documents/teams/$(oldDoc.team)))
             );
       }
 
@@ -158,11 +162,13 @@ service cloud.firestore {
             request.resource.data.users.keys().hasOnly(resource.data.users.keys()) &&
             request.resource.data.invite == resource.data.invite;
 
-      // Let users remove themselves from their team if they don't make any
-      // other changes to the doc.
+      // Let users remove themselves from their team if they hadn't reported any
+      // climbs and don't make any other changes to the doc.
       allow update:
-        if loggedIn() && // skip teamDocValid() since it expects user on team
+        if loggedIn() &&
+            // Skip teamDocValid() since it expects user to be on team.
             request.auth.uid in resource.data.users &&
+            resource.data.users[request.auth.uid].climbs.size() == 0 &&
             !(request.auth.uid in request.resource.data.users) &&
             request.resource.data.users.size() == resource.data.users.size() - 1 &&
             request.resource.data.name == resource.data.name &&

--- a/src/models.ts
+++ b/src/models.ts
@@ -80,18 +80,22 @@ export interface Team {
   name: string;
   invite: string;
   users: Record<string, TeamUserData>;
+  abandoned?: boolean; // only if a user left after climbs were recorded
 }
+
+// Number of members on a complete team.
+export const TeamSize = 2;
 
 // TeamUserData represents a record in the 'users' field in a document in the
 // 'teams' collection.
 export interface TeamUserData {
   name: string;
   climbs: Record<string, ClimbState>;
+  left?: boolean; // only if the user left the team after it was abandoned
 }
 
 // User represents a document in the 'users' collection.
 export interface User {
   name: string;
   team?: string; // only if on a team
-  climbs?: Record<string, ClimbState>; // only if not on a team
 }

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -14,7 +14,7 @@
       </template>
       <RouteList
         :id="'routes-list-' + area.id"
-        :climberInfos="climberInfos"
+        :climberInfos="teamFull ? climberInfos : []"
         :routes="area.routes"
         @set-climb-state="onSetClimbState"
       />
@@ -37,6 +37,7 @@ import {
   ClimbState,
   SetClimbStateEvent,
   SortedData,
+  TeamSize,
 } from '@/models';
 
 import Perf from '@/mixins/Perf';
@@ -73,6 +74,13 @@ export default class Routes extends Mixins(Perf, UserLoader) {
         Routes.climbColors[i % Routes.climbColors.length]
       );
     });
+  }
+
+  // Returns true if the team is full.
+  get teamFull() {
+    return (
+      this.teamDoc.users && Object.keys(this.teamDoc.users).length == TeamSize
+    );
   }
 
   // Updates team document in response to 'set-climb-state' events from RouteList

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -138,8 +138,10 @@ export default class Statistics extends Mixins(Perf, UserLoader) {
       );
 
       this.teamCards = this.computeStats(userClimbs);
-    } else if (this.userDoc.climbs) {
-      this.userCards = this.computeStats([this.userDoc.climbs]);
+    } else {
+      // TODO: Should we track individual stats separately for the case where a
+      // user switches teams? Probably enough of an edge case to not bother...
+      this.userCards = [];
     }
 
     this.haveStats = true;


### PR DESCRIPTION
Remove old logic that transferred a user's climbs from the
team doc to their user doc when they left their team.
Instead, if a user leaves a team after reporting climbs,
preserve their entry in the team's 'users' map. We let the
user re-join the team later but no one else can take their
place.

Also update end-to-end tests to use two separate users.