### PR TITLE
Use Travis's "chrome" addon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,9 @@ matrix:
       node_js: lts/*
       addons:
         apt:
-          sources:
-            - google-chrome
           packages:
             - awscli
-            - google-chrome-stable
+        chrome: stable
       install:
         - npm install
         - firebase setup:emulators:firestore


### PR DESCRIPTION
https://travis-ci.org/derat/ascenso/jobs/583849438 failed
with "session not created: This version of ChromeDriver only
supports Chrome version 76". It looks like Travis is
currently installing google-chrome-stable 73.0.3683.86-1; I
have no idea why. I'm switching from manually installing the
package to using the addon thing at
https://docs.travis-ci.com/user/chrome to see if it helps.