### PR TITLE
Make end-to-end tests wait 15 seconds for login page.

### DIFF
--- a/e2e/pages/login.ts
+++ b/e2e/pages/login.ts
@@ -14,7 +14,9 @@ module.exports = {
     // Signs in using |email| and |password| and blocks until the login page is
     // no longer loaded.
     signIn(email: string, password: string) {
-      return this.waitForElementVisible('@startButton')
+      // Wait a while since the page (or at least FirebaseUI) sometimes seems to
+      // take a while to load.
+      return this.waitForElementVisible('@startButton', 15_000)
         .click('@startButton')
         .waitForElementVisible('@emailInput')
         .setValue('@emailInput', email)


### PR DESCRIPTION
Increase Nightwatch's default 5-second timeout to 15 seconds
when waiting for the login page to appear. I'm still
grasping at straws about why there are failures in the
nightly Travis runs.