### PR TITLE
Improve performance when expanding areas in Routes view.

### DIFF
--- a/e2e/pages/login.ts
+++ b/e2e/pages/login.ts
@@ -26,7 +26,7 @@ module.exports = {
         .setValue('@passwordInput', password)
         .waitForElementVisible('@nextButton')
         .click('@nextButton')
-        .waitForElementNotPresent('@wrapper');
+        .waitForElementNotPresent('@wrapper', 15_000);
     },
   },
 };

--- a/src/views/Routes.test.ts
+++ b/src/views/Routes.test.ts
@@ -89,11 +89,7 @@ describe('Routes', () => {
     );
   });
 
-  it('passes data to route lists', async () => {
-    // Expand all areas to instantiate lazily-initialized RouteLists.
-    wrapper.findAll('.area').wrappers.forEach(w => w.trigger('click'));
-    await flushPromises();
-
+  it('passes data to route lists', () => {
     const routeLists = wrapper.findAll(RouteList).wrappers;
     expect(routeLists.map(w => w.props('routes'))).toEqual(
       sortedData.areas.map(a => a.routes)
@@ -111,10 +107,6 @@ describe('Routes', () => {
   });
 
   it('updates climb states', async () => {
-    // Expand all areas to instantiate lazily-initialized RouteLists.
-    wrapper.findAll('.area').wrappers.forEach(w => w.trigger('click'));
-    await flushPromises();
-
     // Simulate the first climber leading the third route and the second climber
     // undoing their lead of the second route.
     const routeLists = wrapper.findAll(RouteList).wrappers;

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -3,7 +3,14 @@
      found in the LICENSE file. -->
 
 <template>
-  <v-expansion-panels v-if="ready" multiple>
+  <!-- Set 'accordion' here to avoid animating margins between expanded panels
+       and their neighbors, which is a Vuetify 2 thing that seems to kill
+       performance even on not-slow phones (e.g. Pixel 2). -->
+  <!-- TODO: I think that this is probably just a symptom of a more general
+       performance regression in Vuetify 2, tracked by
+       https://github.com/vuetifyjs/vuetify/issues/8298. Remove it if/when that
+       bug is fixed. -->
+  <v-expansion-panels v-if="ready" accordion multiple>
     <v-expansion-panel
       v-for="area in sortedData.areas"
       :key="area.id"
@@ -12,7 +19,12 @@
       <v-expansion-panel-header class="area">
         {{ area.name }}
       </v-expansion-panel-header>
-      <v-expansion-panel-content>
+      <!-- Expansion panel content became lazily-rendered in Vuetify 2. To avoid
+           jank whenever the user expands a panel, set 'eager' here so that all
+           route lists are rendered upfront. -->
+      <!-- TODO: Same comment as above about reevaluating if this is necessary
+           after https://github.com/vuetifyjs/vuetify/issues/8298 is fixed. -->
+      <v-expansion-panel-content eager>
         <RouteList
           :id="'routes-list-' + area.id"
           :climberInfos="teamFull ? climberInfos : []"


### PR DESCRIPTION
After the move to Vuetify 2, expanding areas in the Routes
view became super-janky on a Pixel 2 phone running Chrome
77. Setting the 'accordion' attribute on v-expansion-panels
and 'eager' on v-expansion-panel-content seems to improve
this.

Unrelatedly, increase the login timeout in end-to-end tests
from 5 seconds to 15 seconds, since login depends on an
external service and since I just saw it time out.