### PR TITLE
Support setting grade-based route filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ Heterogeneous singleton documents:
     *   `name` - String field containing the user's name, e.g. "Some Climber".
     *   `team` - String field containing ID of a document in the `teams`
         collection. Unset if the user is not on a team.
+    *   `filters` - Map field containing route filter data. Unset if no filters
+        are set.
+        *   `minGrade` - String field containing minimum grade. Unset if equal
+            to the easiest route's grade.
+        *   `maxGrade` - String field containing maximum grade. Unset if equal
+            to the hardest route's grade.

--- a/src/components/GradeSlider.test.ts
+++ b/src/components/GradeSlider.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import Vue from 'vue';
+import { mount, Wrapper } from '@vue/test-utils';
+import { setUpVuetifyTesting, newVuetifyMountOptions } from '@/testutil';
+
+import GradeSlider from './GradeSlider.vue';
+import { Grades } from '@/models';
+
+setUpVuetifyTesting();
+
+describe('GradeSlider', () => {
+  let wrapper: Wrapper<Vue>;
+
+  // Initializes |wrapper| with the supplied properties.
+  function init(value: [string, string], min: string, max: string) {
+    const propsData = { value, min, max };
+    wrapper = mount(GradeSlider, newVuetifyMountOptions({ propsData }));
+  }
+
+  // Updates |wrapper|'s v-range-slider to span the supplied grades.
+  function setSlider(min: string, max: string) {
+    wrapper.setData({
+      sliderValue: [Grades.indexOf(min), Grades.indexOf(max)],
+    });
+  }
+
+  it('emits events when slider is changed', () => {
+    init(['5.6', '5.11a'], '5.5', '5.12a');
+    setSlider('5.8', '5.10a');
+    setSlider('5.9', '5.10c');
+    expect(wrapper.emitted('input')).toEqual([
+      [['5.8', '5.10a']],
+      [['5.9', '5.10c']],
+    ]);
+  });
+
+  it('updates slider when value property is changed', () => {
+    init(['5.5', '5.12a'], '5.5', '5.12a');
+    wrapper.setProps({ value: ['5.8', '5.11c'] });
+    expect(wrapper.find({ ref: 'slider' }).props('value')).toEqual([
+      Grades.indexOf('5.8'),
+      Grades.indexOf('5.11c'),
+    ]);
+  });
+});

--- a/src/components/GradeSlider.vue
+++ b/src/components/GradeSlider.vue
@@ -1,0 +1,124 @@
+<!-- Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file. -->
+
+<template>
+  <!-- It would be nice to add the 'ticks' attribute here, which allegedly
+       "shows ticks when using [the] slider", but since we also define labels
+       it seems to instead make the ticks always be shown, which looks pretty
+       ugly. -->
+  <v-range-slider
+    ref="slider"
+    :min="minSliderValue"
+    :max="maxSliderValue"
+    :tick-labels="tickLabels"
+    :tick-size="0"
+    thumb-label
+    :thumb-size="40"
+    v-model="sliderValue"
+  >
+    <template v-slot:thumb-label="props">
+      {{ thumbLabel(props.value) }}
+    </template>
+  </v-range-slider>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Grades } from '@/models';
+
+@Component
+export default class GradeSlider extends Vue {
+  // The selected grade range as a pair of values from the Grades array, e.g.
+  // ['5.7, 5.10b']. Should be bound using v-model. When modifying this from
+  // outside of the component, make sure that you reassign the array instead of
+  // indexing into it -- see e.g.
+  // https://vuejs.org/2016/02/06/common-gotchas/#Why-isn’t-the-DOM-updating.
+  @Prop({
+    type: Array,
+    validator: v => Grades.indexOf(v[0]) != -1 && Grades.indexOf(v[1]) != -1,
+  })
+  value!: [string, string];
+
+  // Minimum and maximum grades that should be selectable, as values from the
+  // Grades array, e.g. '5.9+'.
+  @Prop({
+    type: String,
+    validator: v => Grades.indexOf(v) != -1,
+  })
+  min!: string;
+
+  @Prop({
+    type: String,
+    validator: v => Grades.indexOf(v) != -1,
+  })
+  max!: string;
+
+  // Model for the v-slider. The strings in |value| are mapped to integer values
+  // for the slider, and slider-triggered updates produce 'input' events to make
+  // the parent component's v-model binding get updated. For details, see
+  // https://vuejs.org/v2/guide/components.html#Using-v-model-on-Components.
+  get sliderValue(): [number, number] {
+    return [Grades.indexOf(this.value[0]), Grades.indexOf(this.value[1])];
+  }
+  set sliderValue(v: [number, number]) {
+    this.$emit('input', [Grades[v[0]], Grades[v[1]]]);
+  }
+
+  // Minimum and maximum values for the v-range-slider.
+  get minSliderValue() {
+    return Grades.indexOf(this.min);
+  }
+  get maxSliderValue() {
+    return Grades.indexOf(this.max);
+  }
+
+  // Labels for tick marks.
+  // Empty strings are returned to leave some ticks unlabeled.
+  get tickLabels(): string[] {
+    const range = Grades.slice(this.minSliderValue, this.maxSliderValue + 1);
+    return range.map((g, i) => {
+      // Always label the min grade.
+      if (g == this.min) return g;
+      // Don't label grades that would be too close to the left edge.
+      if (i <= 2) return '';
+      // For everything else, just display periodic labels.
+      switch (g) {
+        case '5.0':
+          return '5.0';
+        case '5.2':
+          return '5.2';
+        case '5.4':
+          return '5.4';
+        case '5.6':
+          return '5.6';
+        case '5.8':
+          return '5.8';
+        case '5.10a':
+          return '5.10';
+        case '5.11a':
+          return '5.11';
+        case '5.12a':
+          return '5.12';
+        case '5.13a':
+          return '5.13';
+        case '5.14a':
+          return '5.14';
+        default:
+          return '';
+      }
+    });
+  }
+
+  // Label for the "thumb" containing the current grade.
+  thumbLabel(v: number): string {
+    return Grades[v];
+  }
+}
+</script>
+
+<style scoped>
+>>> .v-slider__tick-label {
+  font-size: 12px;
+}
+</style>

--- a/src/models.ts
+++ b/src/models.ts
@@ -35,6 +35,47 @@ export class Statistic {
   ) {}
 }
 
+// Climbing grades in ascending order.
+// TODO: Consider including '5.10-', '5.11+', etc., or at least having some way
+// of mapping them to 5.10a/b, 5.11c/d, etc.
+export const Grades = [
+  '5.0',
+  '5.1',
+  '5.2',
+  '5.3',
+  '5.4',
+  '5.5',
+  '5.6',
+  '5.7',
+  '5.8',
+  '5.9',
+  '5.9+',
+  '5.10a',
+  '5.10b',
+  '5.10c',
+  '5.10d',
+  '5.11a',
+  '5.11b',
+  '5.11c',
+  '5.11d',
+  '5.12a',
+  '5.12b',
+  '5.12c',
+  '5.12d',
+  '5.13a',
+  '5.13b',
+  '5.13c',
+  '5.13d',
+  '5.14a',
+  '5.14b',
+  '5.14c',
+  '5.14d',
+  '5.15a',
+  '5.15b',
+  '5.15c',
+  '5.15d',
+];
+
 // SetClimbStateEvent is emitted in a 'set-climb-state' event by the RouteList
 // component when the climb state for a route is changed.
 export class SetClimbStateEvent {
@@ -98,4 +139,11 @@ export interface TeamUserData {
 export interface User {
   name: string;
   team?: string; // only if on a team
+  filters?: UserFilterData; // only if non-empty
+}
+
+// UserFilterData represents route filter data inside User.
+export interface UserFilterData {
+  minGrade?: string; // only if not equal to easiest climb's grade
+  maxGrade?: string; // only if not equal to hardest climb's grade
 }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -9,6 +9,7 @@ import Login from '@/views/Login.vue';
 import Print from '@/views/Print.vue';
 import Profile from '@/views/Profile.vue';
 import Routes from '@/views/Routes.vue';
+import RoutesNav from '@/views/RoutesNav.vue';
 import Statistics from '@/views/Statistics.vue';
 
 export default [
@@ -35,7 +36,10 @@ export default [
   {
     name: 'routes',
     path: '/routes',
-    component: Routes,
+    components: {
+      default: Routes,
+      nav: RoutesNav,
+    },
     meta: {
       auth: true,
       title: 'Routes',

--- a/src/views/Routes.test.ts
+++ b/src/views/Routes.test.ts
@@ -5,7 +5,12 @@
 import { MockFirebase, MockUser } from '@/firebase/mock';
 
 import { mount, Wrapper } from '@vue/test-utils';
-import { setUpVuetifyTesting, newVuetifyMountOptions } from '@/testutil';
+import {
+  setUpVuetifyTesting,
+  newVuetifyMountOptions,
+  deepCopy,
+  getValue,
+} from '@/testutil';
 import Vue from 'vue';
 import flushPromises from 'flush-promises';
 
@@ -28,6 +33,7 @@ const testName = 'Test User';
 const otherUID = '456';
 const otherName = 'Other User';
 const teamID = 'test-team';
+
 const sortedData: SortedData = {
   areas: [
     {
@@ -64,6 +70,9 @@ const teamDoc: Team = {
   },
 };
 
+const minGrade = '5.7'; // from sortedData
+const maxGrade = '5.12c'; // from sortedData
+
 describe('Routes', () => {
   let wrapper: Wrapper<Vue>;
 
@@ -74,6 +83,12 @@ describe('Routes', () => {
     MockFirebase.setDoc(`users/${testUID}`, userDoc);
     MockFirebase.setDoc(`teams/${teamID}`, teamDoc);
 
+    await mountView();
+  });
+
+  // Mounts the Routes view and updates |wrapper|.
+  // Can be called by tests to remount after changing Firestore data.
+  async function mountView() {
     wrapper = mount(
       Routes,
       newVuetifyMountOptions({
@@ -81,7 +96,13 @@ describe('Routes', () => {
       })
     );
     await flushPromises();
-  });
+  }
+
+  // Emits an event to display the filters dialog.
+  // In reality, this event is emitted by the RoutesNav view.
+  function showFiltersDialog() {
+    wrapper.vm.$root.$emit('show-route-filters');
+  }
 
   it('displays all areas', () => {
     expect(wrapper.findAll('.area').wrappers.map(w => w.text())).toEqual(
@@ -134,5 +155,65 @@ describe('Routes', () => {
       expected.users[testUID].climbs,
       expected.users[otherUID].climbs,
     ]);
+  });
+
+  it('displays filters dialog', () => {
+    const dialog = wrapper.find({ ref: 'filtersDialog' });
+    expect(getValue(dialog)).toBeFalsy();
+    showFiltersDialog();
+    expect(getValue(dialog)).toBeTruthy();
+
+    // The slider should cover the range of grades from the sortedData doc.
+    const slider = wrapper.find({ ref: 'filtersGradeSlider' });
+    expect(slider.props('min')).toBe(minGrade);
+    expect(slider.props('max')).toBe(maxGrade);
+    expect(slider.props('value')).toEqual([minGrade, maxGrade]);
+    expect(wrapper.find({ ref: 'filtersGradeLabel' }).text()).toBe(
+      `Grades: ${minGrade} to ${maxGrade}`
+    );
+  });
+
+  it('loads previously-set filters', async () => {
+    // Write custom filters to Firestore and remount the view.
+    const doc = deepCopy(userDoc);
+    doc.filters = { minGrade: '5.9', maxGrade: '5.11a' };
+    MockFirebase.setDoc(`users/${testUID}`, doc);
+    await mountView();
+
+    // The slider should be initialized to the range from the user doc.
+    showFiltersDialog();
+    const slider = wrapper.find({ ref: 'filtersGradeSlider' });
+    expect(slider.props('min')).toBe(minGrade);
+    expect(slider.props('max')).toBe(maxGrade);
+    expect(slider.props('value')).toEqual(['5.9', '5.11a']);
+    expect(wrapper.find({ ref: 'filtersGradeLabel' }).text()).toBe(
+      `Grades: 5.9 to 5.11a`
+    );
+  });
+
+  it('saves filters to user doc', async () => {
+    showFiltersDialog();
+    const slider = wrapper.find({ ref: 'filtersGradeSlider' });
+    slider.vm.$emit('input', ['5.9', '5.11a']);
+    expect(wrapper.find({ ref: 'filtersGradeLabel' }).text()).toBe(
+      `Grades: 5.9 to 5.11a`
+    );
+    const button = wrapper.find({ ref: 'applyFiltersButton' });
+    button.trigger('click');
+    await flushPromises();
+
+    const doc = deepCopy(userDoc);
+    doc.filters = { minGrade: '5.9', maxGrade: '5.11a' };
+    expect(MockFirebase.getDoc(`users/${testUID}`)).toEqual(doc);
+
+    // If the selected grades match the full range, the filters should be
+    // cleared in the user doc.
+    showFiltersDialog();
+    slider.vm.$emit('input', [minGrade, maxGrade]);
+    button.trigger('click');
+    await flushPromises();
+
+    delete doc.filters;
+    expect(MockFirebase.getDoc(`users/${testUID}`)).toEqual(doc);
   });
 });

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -3,37 +3,76 @@
      found in the LICENSE file. -->
 
 <template>
-  <!-- Set 'accordion' here to avoid animating margins between expanded panels
-       and their neighbors, which is a Vuetify 2 thing that seems to kill
-       performance even on not-slow phones (e.g. Pixel 2). -->
-  <!-- TODO: I think that this is probably just a symptom of a more general
+  <div v-if="ready">
+    <!-- Set 'accordion' here to avoid animating margins between expanded panels
+         and their neighbors, which is a Vuetify 2 thing that seems to kill
+         performance even on not-slow phones (e.g. Pixel 2). -->
+    <!-- TODO: I think that this is probably just a symptom of a more general
        performance regression in Vuetify 2, tracked by
        https://github.com/vuetifyjs/vuetify/issues/8298. Remove it if/when that
        bug is fixed. -->
-  <v-expansion-panels v-if="ready" accordion multiple>
-    <v-expansion-panel
-      v-for="area in sortedData.areas"
-      :key="area.id"
-      :id="'routes-expand-' + area.id"
+    <v-expansion-panels accordion multiple>
+      <v-expansion-panel
+        v-for="area in sortedData.areas"
+        :key="area.id"
+        :id="'routes-expand-' + area.id"
+      >
+        <v-expansion-panel-header class="area">
+          {{ area.name }}
+        </v-expansion-panel-header>
+        <!-- Expansion panel content became lazily-rendered in Vuetify 2. To
+             avoid jank whenever the user expands a panel, set 'eager' here so
+             that all route lists are rendered upfront. -->
+        <!-- TODO: Same comment as above about reevaluating if this is necessary
+             after https://github.com/vuetifyjs/vuetify/issues/8298 is fixed.
+             -->
+        <v-expansion-panel-content eager>
+          <RouteList
+            :id="'routes-list-' + area.id"
+            :climberInfos="teamFull ? climberInfos : []"
+            :routes="area.routes"
+            @set-climb-state="onSetClimbState"
+          />
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+
+    <v-dialog
+      ref="filtersDialog"
+      v-model="filtersDialogShown"
+      max-width="512px"
     >
-      <v-expansion-panel-header class="area">
-        {{ area.name }}
-      </v-expansion-panel-header>
-      <!-- Expansion panel content became lazily-rendered in Vuetify 2. To avoid
-           jank whenever the user expands a panel, set 'eager' here so that all
-           route lists are rendered upfront. -->
-      <!-- TODO: Same comment as above about reevaluating if this is necessary
-           after https://github.com/vuetifyjs/vuetify/issues/8298 is fixed. -->
-      <v-expansion-panel-content eager>
-        <RouteList
-          :id="'routes-list-' + area.id"
-          :climberInfos="teamFull ? climberInfos : []"
-          :routes="area.routes"
-          @set-climb-state="onSetClimbState"
-        />
-      </v-expansion-panel-content>
-    </v-expansion-panel>
-  </v-expansion-panels>
+      <DialogCard title="Route filters">
+        <v-subheader ref="filtersGradeLabel">
+          Grades: {{ filtersDialogGrades[0] }} to {{ filtersDialogGrades[1] }}
+        </v-subheader>
+        <v-card-text>
+          <GradeSlider
+            ref="filtersGradeSlider"
+            :min="minGrade"
+            :max="maxGrade"
+            v-model="filtersDialogGrades"
+          />
+        </v-card-text>
+
+        <v-divider />
+        <v-card-actions>
+          <v-btn text @click="onCancelFilters">
+            Cancel
+          </v-btn>
+          <v-spacer />
+          <v-btn
+            ref="applyFiltersButton"
+            text
+            color="primary"
+            @click="onApplyFilters"
+          >
+            Apply
+          </v-btn>
+        </v-card-actions>
+      </DialogCard>
+    </v-dialog>
+  </div>
   <Spinner v-else />
 </template>
 
@@ -49,26 +88,41 @@ import { logInfo, logError } from '@/log';
 import {
   ClimberInfo,
   ClimbState,
+  Grades,
   SetClimbStateEvent,
   SortedData,
   TeamSize,
 } from '@/models';
 
+import DialogCard from '@/components/DialogCard.vue';
+import GradeSlider from '@/components/GradeSlider.vue';
 import Perf from '@/mixins/Perf';
 import RouteList from '@/components/RouteList.vue';
 import Spinner from '@/components/Spinner.vue';
 import UserLoader from '@/mixins/UserLoader';
 
 @Component({
-  components: { RouteList, Spinner },
+  components: { DialogCard, GradeSlider, RouteList, Spinner },
 })
 export default class Routes extends Mixins(Perf, UserLoader) {
-  readonly sortedData: Partial<SortedData> = {};
-  // True after information is loaded.
-  loadedSortedData = false;
-
   // Colors associated with climbers.
   static readonly climbColors = ['red', 'indigo'];
+
+  // Cloud Firestore document containing sorted areas and routes.
+  readonly sortedData: Partial<SortedData> = {};
+  // True after |sortedData| is loaded.
+  loadedSortedData = false;
+
+  // Minimum and maximum grades of routes in |sortedData|.
+  minGrade = Grades[0];
+  maxGrade = Grades[Grades.length - 1];
+
+  // Controls whether the filters dialog is shown or not.
+  filtersDialogShown = false;
+  // Grades currently selected in the filters dialog. These grades may not have
+  // been applied yet; the filter data from |userDoc| should be used instead for
+  // actually performing filtering.
+  filtersDialogGrades = [this.minGrade, this.maxGrade];
 
   // Sorted UIDs from the team. Empty if the user is not currently on a team.
   get teamMembers(): string[] {
@@ -132,6 +186,38 @@ export default class Routes extends Mixins(Perf, UserLoader) {
     return this.loadedSortedData && this.userLoaded;
   }
 
+  @Watch('sortedData')
+  onSortedDataChanged() {
+    // Update the minimum and maximum grades available for filtering.
+    let min = Grades.length - 1;
+    let max = 0;
+    if (this.sortedData && this.sortedData.areas) {
+      for (const a of this.sortedData.areas) {
+        if (!a.routes) continue;
+        for (const r of a.routes) {
+          const i = Grades.indexOf(r.grade);
+          if (i == -1) continue;
+          min = Math.min(min, i);
+          max = Math.max(max, i);
+        }
+      }
+    }
+
+    // If we didn't see any recognizable grades, just use the full range.
+    if (min > max) {
+      min = 0;
+      max = Grades.length - 1;
+    }
+
+    // Update the filter for the allowable range.
+    this.minGrade = Grades[min];
+    this.maxGrade = Grades[max];
+    this.filtersDialogGrades = [
+      Grades[Math.max(Grades.indexOf(this.filtersDialogGrades[0]), min)],
+      Grades[Math.min(Grades.indexOf(this.filtersDialogGrades[1]), max)],
+    ];
+  }
+
   @Watch('ready')
   onReady(val: boolean) {
     if (val) this.logReady('routes_loaded');
@@ -141,6 +227,19 @@ export default class Routes extends Mixins(Perf, UserLoader) {
   onUserLoadError(err: Error) {
     this.$emit('error-msg', `Failed loading user or team: ${err.message}`);
     logError('routes_load_user_or_team_failed', err);
+  }
+
+  // Resets the filter dialog to match the filters in the user doc.
+  @Watch('userDoc.filters')
+  resetFilterDialog() {
+    if (this.userDoc && this.userDoc.filters) {
+      this.filtersDialogGrades = [
+        this.userDoc.filters.minGrade || this.minGrade,
+        this.userDoc.filters.maxGrade || this.maxGrade,
+      ];
+    } else {
+      this.filtersDialogGrades = [this.minGrade, this.maxGrade];
+    }
   }
 
   mounted() {
@@ -163,6 +262,50 @@ export default class Routes extends Mixins(Perf, UserLoader) {
         }
       );
     });
+
+    // Listen for events emitted by the RoutesNav view.
+    this.$root.$on('show-route-filters', () => {
+      this.filtersDialogShown = true;
+    });
+  }
+
+  // Handles the 'Cancel' button being clicked in the filters dialog.
+  // The dialog is reverted to contain the settings from Cloud Firestore.
+  onCancelFilters() {
+    this.resetFilterDialog();
+    this.filtersDialogShown = false;
+  }
+
+  // Handles the 'Apply' button being clicked in the filters dialog.
+  // The updated filter settings are saved to Cloud Firestore.
+  onApplyFilters() {
+    new Promise(resolve => {
+      const min = this.filtersDialogGrades[0];
+      const max = this.filtersDialogGrades[1];
+      logInfo('update_route_filters', { min, max });
+      if (!this.userRef) throw new Error('No ref to user doc');
+
+      // TODO: Should we display some sort of spinner while waiting for this to
+      // complete? Should we dismiss the dialog immediately and update in the
+      // background?
+      const filters: Record<string, any> = {};
+      if (min != this.minGrade) filters.minGrade = min;
+      if (max != this.maxGrade) filters.maxGrade = max;
+      resolve(
+        this.userRef.update({
+          filters: Object.keys(filters).length
+            ? filters
+            : this.firebase.firestore.FieldValue.delete(),
+        })
+      );
+    })
+      .catch(err => {
+        this.$emit('error-msg', `Failed updating filters: ${err.message}`);
+        logError('update_route_filters_failed', err);
+      })
+      .finally(() => {
+        this.filtersDialogShown = false;
+      });
   }
 }
 </script>

--- a/src/views/RoutesNav.vue
+++ b/src/views/RoutesNav.vue
@@ -1,0 +1,21 @@
+<!-- Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file. -->
+
+<template>
+  <v-toolbar-items>
+    <!-- Emit an event on the root Vue instance that the Routes view can listen
+         for. See https://stackoverflow.com/a/47004242 for more about this
+         approach. -->
+    <v-btn text class="white--text" @click="$root.$emit('show-route-filters')"
+      >Filters</v-btn
+    >
+  </v-toolbar-items>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class RoutesNav extends Vue {}
+</script>


### PR DESCRIPTION
Add support for filtering which routes are displayed in the
Routes view, currently just via a minimum and maximum grade.
A new GradeSlider component is introduced and used in a
dialog in the Routes view. A new RoutesNav component is also
used to place a "Filters" button in the toolbar for opening
the dialog.

Filters are saved to the user doc in Cloud Firestore, but
they aren't reflected in the route listing yet.