### PR TITLE
Make RouteList visually deemphasize filtered-out routes.

### DIFF
--- a/src/components/GradeSlider.test.ts
+++ b/src/components/GradeSlider.test.ts
@@ -7,7 +7,7 @@ import { mount, Wrapper } from '@vue/test-utils';
 import { setUpVuetifyTesting, newVuetifyMountOptions } from '@/testutil';
 
 import GradeSlider from './GradeSlider.vue';
-import { Grades } from '@/models';
+import { GradeIndexes } from '@/models';
 
 setUpVuetifyTesting();
 
@@ -23,7 +23,7 @@ describe('GradeSlider', () => {
   // Updates |wrapper|'s v-range-slider to span the supplied grades.
   function setSlider(min: string, max: string) {
     wrapper.setData({
-      sliderValue: [Grades.indexOf(min), Grades.indexOf(max)],
+      sliderValue: [GradeIndexes[min], GradeIndexes[max]],
     });
   }
 
@@ -41,8 +41,8 @@ describe('GradeSlider', () => {
     init(['5.5', '5.12a'], '5.5', '5.12a');
     wrapper.setProps({ value: ['5.8', '5.11c'] });
     expect(wrapper.find({ ref: 'slider' }).props('value')).toEqual([
-      Grades.indexOf('5.8'),
-      Grades.indexOf('5.11c'),
+      GradeIndexes['5.8'],
+      GradeIndexes['5.11c'],
     ]);
   });
 });

--- a/src/components/GradeSlider.vue
+++ b/src/components/GradeSlider.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { Grades } from '@/models';
+import { Grades, GradeIndexes } from '@/models';
 
 @Component
 export default class GradeSlider extends Vue {
@@ -34,32 +34,20 @@ export default class GradeSlider extends Vue {
   // outside of the component, make sure that you reassign the array instead of
   // indexing into it -- see e.g.
   // https://vuejs.org/2016/02/06/common-gotchas/#Why-isn’t-the-DOM-updating.
-  @Prop({
-    type: Array,
-    validator: v => Grades.indexOf(v[0]) != -1 && Grades.indexOf(v[1]) != -1,
-  })
+  @Prop({ validator: v => v[0] in GradeIndexes && v[1] in GradeIndexes })
   value!: [string, string];
 
   // Minimum and maximum grades that should be selectable, as values from the
   // Grades array, e.g. '5.9+'.
-  @Prop({
-    type: String,
-    validator: v => Grades.indexOf(v) != -1,
-  })
-  min!: string;
-
-  @Prop({
-    type: String,
-    validator: v => Grades.indexOf(v) != -1,
-  })
-  max!: string;
+  @Prop({ validator: v => v in GradeIndexes }) min!: string;
+  @Prop({ validator: v => v in GradeIndexes }) max!: string;
 
   // Model for the v-slider. The strings in |value| are mapped to integer values
   // for the slider, and slider-triggered updates produce 'input' events to make
   // the parent component's v-model binding get updated. For details, see
   // https://vuejs.org/v2/guide/components.html#Using-v-model-on-Components.
   get sliderValue(): [number, number] {
-    return [Grades.indexOf(this.value[0]), Grades.indexOf(this.value[1])];
+    return [GradeIndexes[this.value[0]], GradeIndexes[this.value[1]]];
   }
   set sliderValue(v: [number, number]) {
     this.$emit('input', [Grades[v[0]], Grades[v[1]]]);
@@ -67,10 +55,10 @@ export default class GradeSlider extends Vue {
 
   // Minimum and maximum values for the v-range-slider.
   get minSliderValue() {
-    return Grades.indexOf(this.min);
+    return GradeIndexes[this.min];
   }
   get maxSliderValue() {
-    return Grades.indexOf(this.max);
+    return GradeIndexes[this.max];
   }
 
   // Labels for tick marks.

--- a/src/models.ts
+++ b/src/models.ts
@@ -76,6 +76,16 @@ export const Grades = [
   '5.15d',
 ];
 
+// Maps from each grade to its index in |Grades|.
+// Presumably faster than calling Grades.indexOf().
+export const GradeIndexes: Record<string, number> = Grades.reduce(
+  (res: Record<string, number>, g: string, i: number) => {
+    res[g] = i;
+    return res;
+  },
+  {}
+);
+
 // SetClimbStateEvent is emitted in a 'set-climb-state' event by the RouteList
 // component when the climb state for a route is changed.
 export class SetClimbStateEvent {

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -31,6 +31,8 @@
             :id="'routes-list-' + area.id"
             :climberInfos="teamFull ? climberInfos : []"
             :routes="area.routes"
+            :minGrade="minGradeFilter"
+            :maxGrade="maxGradeFilter"
             @set-climb-state="onSetClimbState"
           />
         </v-expansion-panel-content>
@@ -89,6 +91,7 @@ import {
   ClimberInfo,
   ClimbState,
   Grades,
+  GradeIndexes,
   SetClimbStateEvent,
   SortedData,
   TeamSize,
@@ -144,11 +147,29 @@ export default class Routes extends Mixins(Perf, UserLoader) {
     });
   }
 
-  // Returns true if the team is full.
+  // True if the team is full.
   get teamFull() {
     return (
       this.teamDoc.users && Object.keys(this.teamDoc.users).length == TeamSize
     );
+  }
+
+  // Minimum and maximum grade filters to pass to RouteList components.
+  // Returns undefined if the filter is unset or matches the min/max grade
+  // across all routes (making it a no-op).
+  get minGradeFilter(): string | undefined {
+    return this.userDoc &&
+      this.userDoc.filters &&
+      this.userDoc.filters.minGrade != this.minGrade
+      ? this.userDoc.filters.minGrade
+      : undefined;
+  }
+  get maxGradeFilter(): string | undefined {
+    return this.userDoc &&
+      this.userDoc.filters &&
+      this.userDoc.filters.maxGrade != this.maxGrade
+      ? this.userDoc.filters.maxGrade
+      : undefined;
   }
 
   // Updates team document in response to 'set-climb-state' events from RouteList
@@ -195,8 +216,8 @@ export default class Routes extends Mixins(Perf, UserLoader) {
       for (const a of this.sortedData.areas) {
         if (!a.routes) continue;
         for (const r of a.routes) {
-          const i = Grades.indexOf(r.grade);
-          if (i == -1) continue;
+          const i: number | undefined = GradeIndexes[r.grade];
+          if (i === undefined) continue;
           min = Math.min(min, i);
           max = Math.max(max, i);
         }
@@ -213,8 +234,8 @@ export default class Routes extends Mixins(Perf, UserLoader) {
     this.minGrade = Grades[min];
     this.maxGrade = Grades[max];
     this.filtersDialogGrades = [
-      Grades[Math.max(Grades.indexOf(this.filtersDialogGrades[0]), min)],
-      Grades[Math.min(Grades.indexOf(this.filtersDialogGrades[1]), max)],
+      Grades[Math.max(GradeIndexes[this.filtersDialogGrades[0]], min)],
+      Grades[Math.min(GradeIndexes[this.filtersDialogGrades[1]], max)],
     ];
   }
 


### PR DESCRIPTION
Update the RouteList component to accept minGrade and
maxGrade parameters. If a range is supplied, routes with
grades outside of it are displayed with reduced opacity.

Update the Routes view to pass the range selected via the
filters dialog.