### PR TITLE
Make Travis install latest stable Chromedriver release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
     # These environment variables are public; see .env.example.
     # Private variables are set in the "Environment Variables" section of the
     # Travis settings page.
+    - CHROMEDRIVER_VERSION=LATEST
     - E2E_URL=http://localhost:8080/
     - VUE_APP_APPLE_MASK_COLOR=#d50000
     - VUE_APP_APPLE_MASK_PATH=assets-fallback/safari-pinned-tab.svg


### PR DESCRIPTION
Set the CHROMEDRIVER_VERSION environment variable to
"LATEST" in .travis.yml to instruct the chromedriver Node
package to install the current stable version of
Chromedriver (which is used to control Chrome in end-to-end
testing). See https://www.npmjs.com/package/chromedriver for
more details.

The package's default version of Chromedriver appears to lag
behind Chrome's stable channel:
https://travis-ci.org/derat/ascenso/jobs/601486566 failed
because Chrome 78.0.3904.70 was paired with a version of
Chromedriver that expects Chrome 76.