### PR TITLE
Increase E2E timeout for joining/leaving team to 20 seconds.

### DIFF
--- a/e2e/pages/profile.ts
+++ b/e2e/pages/profile.ts
@@ -50,14 +50,14 @@ module.exports = {
         .setVTextFieldValue('@joinCodeField', inviteCode)
         .waitForElementVisible('@joinConfirmButton')
         .click('@joinConfirmButton')
-        .waitForElementNotVisible('@joinConfirmButton', 10_000);
+        .waitForElementNotVisible('@joinConfirmButton', 20_000);
     },
     leaveTeam() {
       return this.waitForElementVisible('@leaveButton')
         .click('@leaveButton')
         .waitForElementVisible('@leaveConfirmButton')
         .click('@leaveConfirmButton')
-        .waitForElementNotVisible('@leaveConfirmButton', 10_000);
+        .waitForElementNotVisible('@leaveConfirmButton', 20_000);
     },
     showInviteCode(inviteCodeFunc: (code: string) => void) {
       return this.waitForElementVisible('@inviteButton')


### PR DESCRIPTION
Increase the timeout in end-to-end tests for joining or
leaving a team from 10 seconds to 20 seconds. I'm still
seeing occasional failures in the automated Travis runs,
e.g. https://travis-ci.org/derat/ascenso/builds/614736317.
I haven't been able to reproduce the failures locally, but I
assume that Firebase updates are being slow (network
issues?).