### PR TITLE
Instruct Vuetify to use vue-i18n.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,11 @@ module.exports = {
       'jest-transform-stub',
     '^.+\\.tsx?$': 'ts-jest',
   },
-  transformIgnorePatterns: ['/node_modules/'],
+  // By default, Jest is configured to not transform '/node_modules/'. Vuetify's
+  // locale files need to be transformed from TS to JS when they're imported by
+  // src/testutil.ts, though.
+  // See e.g. https://github.com/nrwl/nx/issues/812#issue-369650585.
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!vuetify/src/locale/.*)'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
@@ -20,6 +24,10 @@ module.exports = {
   globals: {
     'ts-jest': {
       babelConfig: true,
+      // Needed to avoid a weird "TypeError: Unable to require `.d.ts` file."
+      // error when importing en.ts. More discussion at
+      // https://github.com/kulshekhar/ts-jest/issues/805.
+      isolatedModules: true,
     },
   },
 };

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -1,0 +1,14 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import en from 'vuetify/src/locale/en';
+
+export default {
+  $vuetify: en,
+  Profile: {
+    yourName: 'Your Name',
+    individual: 'Individual',
+    team: 'Team',
+  },
+};

--- a/src/locale/es.ts
+++ b/src/locale/es.ts
@@ -1,0 +1,14 @@
+// Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import es from 'vuetify/src/locale/es';
+
+export default {
+  $vuetify: es,
+  Profile: {
+    yourName: 'Tu Nombre',
+    individual: 'Individual',
+    team: 'Grupo',
+  },
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,8 +60,6 @@ Vue.use(VueRouter);
 Vue.use(firestorePlugin);
 
 import App from '@/App.vue';
-// TODO: Do we actually need to use this? See
-// https://vuetifyjs.com/en/customization/internationalization
 import i18n from '@/plugins/i18n';
 import vuetify from '@/plugins/vuetify';
 import router from '@/router';

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,28 +1,18 @@
 // Copyright 2019 Daniel Erat and Niniane Wang. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file. 
+// found in the LICENSE file.
 
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 
+import en from '@/locale/en';
+import es from '@/locale/es';
+
 Vue.use(VueI18n);
 
-const messages = {
-  en: {
-    yourName: 'Your Name',
-    individual: 'Individual',
-    team: 'Team',
-  }, 
-  es: {
-    yourName: 'Tu Nombre',
-    individual: 'Individual',
-    team: 'Grupo',
-  }
-};
-
 export default new VueI18n({
+  // TODO: Make this selectable in the UI.
   locale: 'en',
-  fallbackLocale: 'es',
-  messages,
+  fallbackLocale: 'en',
+  messages: { en, es },
 });
-

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -7,10 +7,21 @@ import '@mdi/font/css/materialdesignicons.css';
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib';
 import colors from 'vuetify/lib/util/colors';
+import i18n from '@/plugins/i18n';
 
 Vue.use(Vuetify);
 
 export default new Vuetify({
+  lang: {
+    // Make Vuetify use vue-i18n for translations:
+    // https://vuetifyjs.com/en/customization/internationalization
+    //
+    // Per the docs, we should be able to return the result of t() directly
+    // here, but in reality it returns a TranslateResult, which is the type
+    // string | LocaleMessages. See
+    // https://github.com/kazupon/vue-i18n/issues/410 for discussion.
+    t: (key, ...params) => i18n.t(key, params).toString(),
+  },
   theme: {
     themes: {
       light: {

--- a/src/testutil.ts
+++ b/src/testutil.ts
@@ -8,8 +8,11 @@
 import { createLocalVue, Wrapper } from '@vue/test-utils';
 import _ from 'lodash';
 import Vue from 'vue';
+import VueI18n from 'vue-i18n';
 import Vuetify from 'vuetify';
 import VueRouter from 'vue-router';
+
+import en from '@/locale/en';
 
 // Returns a deep copy of |data|. Embedded objects are cloned.
 export function deepCopy(data: any) {
@@ -20,6 +23,7 @@ export function deepCopy(data: any) {
 // should be called once at the beginning of each test file.
 export function setUpVuetifyTesting() {
   Vue.use(Vuetify);
+  Vue.use(VueI18n);
 
   // Avoid Vuetify log spam: https://github.com/vuetifyjs/vuetify/issues/3456
   // I believe that Vuetify uses the data-app element to attach floating UI
@@ -44,7 +48,12 @@ export function newVuetifyMountOptions(baseOptions?: Object): Object {
   return Object.assign(
     {
       localVue,
-      vuetify: new Vuetify(),
+      vuetify: new Vuetify({}),
+      i18n: new VueI18n({
+        locale: 'en',
+        fallbackLocale: 'en',
+        messages: { en },
+      }),
     },
     baseOptions
   );

--- a/src/views/Profile.test.ts
+++ b/src/views/Profile.test.ts
@@ -12,7 +12,6 @@ import {
   getValue,
 } from '@/testutil';
 import Vue from 'vue';
-import i18n from '@/plugins/i18n';
 import flushPromises from 'flush-promises';
 
 import { ClimbState, Team, User } from '@/models';
@@ -81,10 +80,7 @@ describe('Profile', () => {
     // elements will be expanded.
     wrapper = mount(
       Profile,
-      newVuetifyMountOptions({
-        mocks: MockFirebase.mountMocks,
-        i18n,
-      })
+      newVuetifyMountOptions({ mocks: MockFirebase.mountMocks })
     );
 
     await flushPromises();

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -4,7 +4,7 @@
 
 <template>
   <v-container v-if="userLoaded">
-    <Card :title="$t('individual')">
+    <Card :title="$t('Profile.individual')">
       <v-spacer class="mt-3" />
       <v-form v-model="userNameValid" @submit.prevent>
         <!-- It's exceedingly unfortunate that all of these elements have
@@ -21,13 +21,13 @@
           :value="userDoc.name"
           :counter="nameMaxLength"
           :rules="nameRules"
-          :label="$t('yourName')"
+          :label="$t('Profile.yourName')"
           @change="updateUserName"
         />
       </v-form>
     </Card>
 
-    <Card :title="$t('team')" class="py-3">
+    <Card :title="$t('Profile.team')" class="py-3">
       <v-spacer class="mt-3" />
 
       <!-- User is on a team -->


### PR DESCRIPTION
Configure Vuetify to use vue-i18n for its own translations.
https://vuetifyjs.com/en/customization/internationalization
has more information.

Also restructure our vue-i18n code so that each language has
its own file under src/locale and so that each component's
translations are grouped together, and simplify vue-i18n
setup for tests.

I'd initially thought we could drop vue-i18n and switch to
just using Vuetify's built-in i18n support, but it seems
like it's less featureful than vue-i18n (e.g. no
pluralization support).