### PR TITLE
Try to fix profile dialog dismissal race in E2E tests.

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -47,9 +47,13 @@
         <div class="caption grey--text text--darken-1">
           {{ $t('Profile.teamMembersLabel') }}
         </div>
-        <div v-for="user in teamMembers" :key="user.name" class="member-name">
-          {{ user.name }}
-          <span v-if="user.left">{{ $t('Profile.teamMemberLeftLabel') }}</span>
+        <div id="profile-team-members">
+          <div v-for="user in teamMembers" :key="user.name" class="member-name">
+            {{ user.name }}
+            <span v-if="user.left">{{
+              $t('Profile.teamMemberLeftLabel')
+            }}</span>
+          </div>
         </div>
 
         <v-divider class="mt-2 mb-4" />


### PR DESCRIPTION
Update E2E tests to use different logic after dismissing
dialogs to avoid an apparent race where Nightwatch's
waitForElementNotVisible() method fails if Vue has already
removed the selected element from the DOM. Also increase
createTeam()'s timeout to 20 seconds to match other methods.

Additionally, remove an incorrect early return in
checkUserOnTeam() that resulted in the team roster not
actually being checked, and fix the check to look at the
full roster instead of just seeing the first member. (Why
didn't TypeScript issue an unreachable code error about the
early return?)