### PR TITLE
Increase E2E timeout when waiting for login email field.

### DIFF
--- a/e2e/pages/login.ts
+++ b/e2e/pages/login.ts
@@ -16,9 +16,9 @@ module.exports = {
     signIn(email: string, password: string) {
       // Wait a while since the page (or at least FirebaseUI) sometimes seems to
       // take a while to load.
-      return this.waitForElementVisible('@startButton', 15_000)
+      return this.waitForElementVisible('@startButton', 20_000)
         .click('@startButton')
-        .waitForElementVisible('@emailInput')
+        .waitForElementVisible('@emailInput', 20_000)
         .setValue('@emailInput', email)
         .waitForElementVisible('@nextButton')
         .click('@nextButton')
@@ -26,7 +26,7 @@ module.exports = {
         .setValue('@passwordInput', password)
         .waitForElementVisible('@nextButton')
         .click('@nextButton')
-        .waitForElementNotPresent('@wrapper', 15_000);
+        .waitForElementNotPresent('@wrapper', 20_000);
     },
   },
 };


### PR DESCRIPTION
I just saw another end-to-end test failure while waiting for
the login page's email field to appear, so increase the
timeout from its default 5 seconds to 20 seconds. Also
increase a few related timeouts from 15 seconds to 20
seconds.