### PR TITLE
Upgrade to Vuetify to v2.2.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21990,9 +21990,9 @@
       }
     },
     "vuetify": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.1.9.tgz",
-      "integrity": "sha512-52CgEyPoGYHba5yocYKBB/LXcikoWzj9jCDTH8LlzH/hvjzkgsuEtFwUustGHyV9GstRaNZOrk4nuUWbPZc3kQ=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.4.tgz",
+      "integrity": "sha512-jhSdCeatWgHrY4Bb2FTi1sFfGDrVHLmkvI7pkG9FEF9TmZ+Qq7Ts85XAft9ucwU8ybB5nDmN6s+oeHJgvL+4tA=="
     },
     "vuetify-loader": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vue-router": "^3.0.7",
     "vue-the-mask": "^0.11.1",
     "vuefire": "^2.1.0",
-    "vuetify": "^2.1.9"
+    "vuetify": "^2.2.4"
   },
   "devDependencies": {
     "@firebase/testing": "^0.12.0",


### PR DESCRIPTION
Update the vuetify package from version 2.1.9 to 2.2.4. Per
the release notes, there are no additional steps needed for
going to 2.2.