### PR TITLE
Upgrade TypeScript ESLint packages.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,2 @@
+> 1%
+last 2 versions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+  },
+  extends: [
+    // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#recommended-configs
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:vue/essential',
+    '@vue/typescript',
+  ],
+  plugins: ['@typescript-eslint/eslint-plugin', 'vuetify'],
+  rules: {
+    'no-console': 'off',
+    // FFS, why does this even exist?
+    '@typescript-eslint/ban-ts-ignore': 'off',
+    // TypeScript already infers return types, so this is obnoxious.
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    // If I use the 'any' type, it's because I meant to use it.
+    '@typescript-eslint/no-explicit-any': 'off',
+    // Allow '!' non-null assertions.
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    // Functions are hoisted, so there's no reason to complain if they're called
+    // before they're defined:
+    // https://eslint.org/docs/rules/no-use-before-define
+    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
+    // Don't yell when we don't use all args passed by third-party code.
+    '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
+    'vuetify/no-deprecated-classes': 'error',
+    'vuetify/grid-unknown-attributes': 'error',
+    'vuetify/no-legacy-grid': 'error',
+  },
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4299,9 +4299,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
     },
     "@types/lodash": {
       "version": "4.14.138",
@@ -4405,22 +4405,17 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz",
-      "integrity": "sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.16.0.tgz",
+      "integrity": "sha512-TKWbeFAKRPrvKiR9GNxErQ8sELKqg1ZvXi6uho07mcKShBnCnqNpDQWP01FEvWKf0bxM2g7uQEI5MNjSNqvUpQ==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.6.1",
-        "eslint-utils": "^1.4.2",
+        "@typescript-eslint/experimental-utils": "2.16.0",
+        "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^2.0.1",
+        "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
-        "regexpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
-        },
         "tsutils": {
           "version": "3.17.1",
           "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
@@ -4432,12 +4427,12 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz",
-      "integrity": "sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.16.0.tgz",
+      "integrity": "sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.6.1",
+        "@typescript-eslint/typescript-estree": "2.16.0",
         "eslint-scope": "^5.0.0"
       },
       "dependencies": {
@@ -4453,13 +4448,13 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.1.tgz",
-      "integrity": "sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.16.0.tgz",
+      "integrity": "sha512-+w8dMaYETM9v6il1yYYkApMSiwgnqXWJbXrA94LAWN603vXHACsZTirJduyeBOJjA9wT6xuXe5zZ1iCUzoxCfw==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.6.1",
-        "@typescript-eslint/typescript-estree": "2.6.1",
+        "@typescript-eslint/experimental-utils": "2.16.0",
+        "@typescript-eslint/typescript-estree": "2.16.0",
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
@@ -4471,18 +4466,42 @@
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz",
-      "integrity": "sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.16.0.tgz",
+      "integrity": "sha512-hyrCYjFHISos68Bk5KjUAXw0pP/455qq9nxqB1KkT67Pxjcfw+r6Yhcmqnp8etFL45UexCHUMrADHH7dI/m2WQ==",
       "requires": {
         "debug": "^4.1.1",
-        "glob": "^7.1.4",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
         "is-glob": "^4.0.1",
-        "lodash.unescape": "4.0.1",
+        "lodash": "^4.17.15",
         "semver": "^6.3.0",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -6855,83 +6874,10 @@
       }
     },
     "@vue/eslint-config-typescript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-4.0.0.tgz",
-      "integrity": "sha512-uSMAMgw4xDgVdZQhpbtJRo8nMV4oOy3Ht8olfOo7xvYFYLMF2JZ1tDRKd9/NSusxA72O2Vma+HzmyzDHg9evcQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/eslint-plugin": "^1.1.0",
-        "@typescript-eslint/parser": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
-          "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/experimental-utils": "1.13.0",
-            "eslint-utils": "^1.3.1",
-            "functional-red-black-tree": "^1.0.1",
-            "regexpp": "^2.0.1",
-            "tsutils": "^3.7.0"
-          }
-        },
-        "@typescript-eslint/experimental-utils": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-          "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "1.13.0",
-            "eslint-scope": "^4.0.0"
-          }
-        },
-        "@typescript-eslint/parser": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-          "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-visitor-keys": "^1.0.0",
-            "@typescript-eslint/experimental-utils": "1.13.0",
-            "@typescript-eslint/typescript-estree": "1.13.0",
-            "eslint-visitor-keys": "^1.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-          "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-          "dev": true,
-          "requires": {
-            "lodash.unescape": "4.0.1",
-            "semver": "5.5.0"
-          }
-        },
-        "regexpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        },
-        "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-5.0.1.tgz",
+      "integrity": "sha512-gpP8zQA0rJ93ROkAW5fbOJB3EG7p6U70Jb0/CVOjhs5zuEXf1WgLk4gP+zUZGwiRpLoXBa5oIRH4hLQDbS1/eg==",
+      "dev": true
     },
     "@vue/preload-webpack-plugin": {
       "version": "1.1.1",
@@ -13706,6 +13652,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17504,11 +17451,6 @@
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
-    },
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -20534,6 +20476,11 @@
           }
         }
       }
+    },
+    "regexpp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+      "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
     },
     "regexpu-core": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:unit:only": "vue-cli-service test:unit --testPathPattern"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.6.1",
-    "@typescript-eslint/parser": "^2.6.1",
+    "@typescript-eslint/eslint-plugin": "^2.16.0",
+    "@typescript-eslint/parser": "^2.16.0",
     "acorn": "^7.1.0",
     "core-js": "^3.4.4",
     "firebase": "^6.6.2",
@@ -44,7 +44,7 @@
     "@vue/cli-plugin-typescript": "^4.1.2",
     "@vue/cli-plugin-unit-jest": "^4.1.2",
     "@vue/cli-service": "^4.1.2",
-    "@vue/eslint-config-typescript": "^4.0.0",
+    "@vue/eslint-config-typescript": "^5.0.1",
     "@vue/test-utils": "^1.0.0-beta.29",
     "axios": "^0.19.0",
     "babel-core": "7.0.0-bridge.0",
@@ -72,37 +72,5 @@
     "vue-jest": "^3.0.4",
     "vue-template-compiler": "^2.6.10",
     "vuetify-loader": "^1.4.3"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/essential",
-      "eslint:recommended",
-      "@vue/typescript"
-    ],
-    "plugins": [
-      "vuetify"
-    ],
-    "rules": {
-      "no-console": "off",
-      "vuetify/no-deprecated-classes": "error",
-      "vuetify/grid-unknown-attributes": "error",
-      "vuetify/no-legacy-grid": "error"
-    },
-    "parserOptions": {
-      "parser": "@typescript-eslint/parser"
-    }
-  },
-  "postcss": {
-    "plugins": {
-      "autoprefixer": {}
-    }
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions"
-  ]
+  }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    autoprefixer: {}
+  }
+};

--- a/src/log/index.ts
+++ b/src/log/index.ts
@@ -16,12 +16,13 @@ const isDev = process.env.NODE_ENV == 'development';
 const isTest = process.env.NODE_ENV == 'test';
 
 // This environment variable is used to increase logging in Travis.
-let devLogDest = process.env.VUE_APP_LOG_TO_CONSOLE
+const devLogDest = process.env.VUE_APP_LOG_TO_CONSOLE
   ? LogDest.CONSOLE
   : LogDest.NONE;
 
 // Returns an appropriate function to pass to the default Logger.
 function getLogFunc(): LogFunc | Promise<LogFunc> {
+  // @ts-ignore: Make it easy to manually change |devLogDest|.
   if (isProd || (isDev && devLogDest == LogDest.STACKDRIVER)) {
     // Return a promise so that importing this module doesn't require
     // synchronously loading bulky Firebase code.
@@ -57,12 +58,10 @@ function log(severity: string, code: string, payload: Record<string, any>) {
         defaultLogger.log(severity, code, payload);
         return;
       }
-      user
-        .getIdToken()
-        .then(
-          token => defaultLogger.log(severity, code, payload, token),
-          err => console.log('Failed to get ID token:', err)
-        );
+      user.getIdToken().then(
+        token => defaultLogger.log(severity, code, payload, token),
+        err => console.log('Failed to get ID token:', err)
+      );
     })
     .catch(err => {
       console.error(`Failed to import Firebase auth code: ${err}`);

--- a/src/log/logger.test.ts
+++ b/src/log/logger.test.ts
@@ -42,7 +42,7 @@ class Endpoint {
   // Data received from Logger via _log().
   _receivedData?: CloudFuncData;
   // Whether _log() should report success to Logger.
-  _logResult: boolean = true;
+  _logResult = true;
 
   // Implementation of the "Log" Cloud Function. Saves the supplied data so it
   // can be passed to the test and returns a promise that will be fulfilled once

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -55,9 +55,9 @@ export class Logger {
   // Prefix used in local storage keys. See makeKeyPrefix().
   _storagePrefix: string;
   // Last time _sendQueued() was called, as milliseconds since the epoch.
-  _lastSendTime: number = 0;
+  _lastSendTime = 0;
   // ID of timeout used to invoke _sendQueued().
-  _sendTimeoutID: number = 0;
+  _sendTimeoutID = 0;
   // Callback for online events.
   _handleOnline: () => void;
 

--- a/src/testutil.ts
+++ b/src/testutil.ts
@@ -38,10 +38,15 @@ export function setUpVuetifyTesting() {
 // Returns a new options object to pass to mount() or shallowMount() when
 // instantiating a Vuetify component for unit tests. If |baseOptions| is
 // supplied, its properties are included in the returned object.
-export function newVuetifyMountOptions(baseOptions?: Object): Object {
+export function newVuetifyMountOptions(
+  baseOptions?: Record<string, any>
+): Record<string, any> {
   // See https://vue-test-utils.vuejs.org/guides/using-with-vue-router.html.
   const localVue = createLocalVue();
-  if (baseOptions && baseOptions.hasOwnProperty('router')) {
+  if (
+    baseOptions &&
+    Object.prototype.hasOwnProperty.call(baseOptions, 'router')
+  ) {
     localVue.use(VueRouter);
   }
 

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -663,7 +663,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
 
   // Helper method for createTeam() that returns a promise for a new, unused
   // invite code.
-  findUnusedInviteCode(remainingTries: number = 9): Promise<string> {
+  findUnusedInviteCode(remainingTries = 9): Promise<string> {
     // We get a string like "0.4948219742736113" and then chop off the left.
     const code = Math.random()
       .toString()

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -77,7 +77,7 @@ export default class Statistics extends Mixins(Perf, UserLoader) {
     let lead = 0;
     let topRope = 0;
     let score = 0;
-    let areas: Record<string, boolean> = {};
+    const areas: Record<string, boolean> = {};
 
     for (const climbs of climbsArray) {
       for (const id of Object.keys(climbs)) {


### PR DESCRIPTION
Manually install @vue/eslint-config-typescript@latest and
upgrade to @typescript-eslint/eslint-plugin@^2.7.0
@typescript-eslint/parser@^2.7.0. This appears to finally
eliminate all of the warnings about unsatisfied peer
dependencies that I'd see when running commands like 'npm
prune'.