### PR TITLE
Save the user's locale selection in a cookie.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23170,6 +23170,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-cookie": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-2.3.1.tgz",
+      "integrity": "sha512-C4x1e8dHfKf03ewuN9aIZzzOfN2a6QKhYlnHdzJxmmjMTLqcskI20F+EplszjODQ4SHmIGFJrvUUnBMS/bJbOA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "firebaseui": "^4.0.0",
     "humanize-duration": "^3.20.1",
     "register-service-worker": "^1.6.2",
+    "tiny-cookie": "^2.3.1",
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.2",
     "vue-i18n": "^8.13.0",

--- a/src/components/LocalePicker.vue
+++ b/src/components/LocalePicker.vue
@@ -21,6 +21,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
+import { set as setCookie } from 'tiny-cookie';
 
 interface LocaleInfo {
   // Locale's name, e.g. 'English (US)'. This should be in the locale's native
@@ -50,6 +51,7 @@ export default class LocalePicker extends Vue {
 
   onClick(lc: string) {
     this.$i18n.locale = lc;
+    setCookie('locale', lc);
   }
 }
 </script>

--- a/src/locale/es-PR.ts
+++ b/src/locale/es-PR.ts
@@ -72,7 +72,7 @@ export default {
     teamMembersLabel: 'Miembros',
     teamNameLabel: 'Nombre de equipo',
     teamTitle: 'Equipo',
-    yourNameLabel: 'Tu Nombre',
+    yourNameLabel: 'Tu nombre',
   },
   Routes: {
     applyButton: 'Aplicar',

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@
 
 import { logError } from '@/log';
 import { getAuth } from '@/firebase';
+import { get as getCookie } from 'tiny-cookie';
 
 const isTestEnv = process.env.NODE_ENV == 'test';
 
@@ -65,6 +66,10 @@ import vuetify from '@/plugins/vuetify';
 import router from '@/router';
 
 import '@/register-service-worker';
+
+// If the user previously selected a locale, apply it before initializing Vue.
+const lc = getCookie('locale');
+if (lc) i18n.locale = lc;
 
 // Defer Vue initialization until Firebase has determined if the user has
 // authenticated or not. Otherwise, router.beforeEach may end up trying to

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -11,7 +11,6 @@ import esPr from '@/locale/es-PR';
 Vue.use(VueI18n);
 
 export default new VueI18n({
-  // TODO: Load from a cookie or the user doc before falling back.
   locale: (process.env.VUE_APP_LOCALES || 'en-US').split(',')[0],
   // If you get bogus-seeming 'Fall back to translate the keypath ___ with "en"
   // language.' warnings even when the translation is defined, make sure that

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -6,11 +6,7 @@
   <div id="login-wrapper">
     <!-- We use v-show rather than v-if here so that FirebaseUI can find the
          auth container in the DOM immediately. -->
-    <v-container
-      class="container text-center"
-      ref="container"
-      v-show="showUI"
-    >
+    <v-container class="container text-center" ref="container" v-show="showUI">
       <v-row justify="center">
         <!-- These widths are chosen to match those of the <Card> below. -->
         <v-col cols="12" sm="8" md="6">
@@ -65,11 +61,30 @@ export default class Login extends Mixins(Perf) {
         this.pendingRedirect = ui.isPendingRedirect();
         if (!this.pendingRedirect) this.logReady('login_loaded');
 
+        // As far as I can tell, there's no way to localize FirebaseUI's auth
+        // interface without loading a completely different version of the
+        // library from the CDN:
+        //
+        // https://github.com/firebase/firebaseui-web#localized-widget
+        // https://github.com/firebase/firebaseui-web/issues/9
+        // https://github.com/firebase/firebaseui-web/issues/242
+        //
+        // Best comment on that last bug:
+        //
+        // > > Each internationalized version is a separate build. Including all
+        // > > the versions in one file is not feasible.
+        //
+        // > Oh dear. Looks like you've used the wrong implementation architecture
+        // > to support i18n for SPA web apps!
+        //
+        // There *is* a |languageCode| field on firebase.auth.Auth, but I'm not
+        // sure what it does:
+        // https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#languagecode
         ui.start('#firebaseui-auth-container', {
           // Disable the account chooser, which is ugly and doesn't seem to work
           // correctly with this logic (i.e. after signing out and trying to
           // sign in with email, I just see a spinner):
-          // https://stackoverflow.com/q/37369929.
+          // https://stackoverflow.com/q/37369929
           credentialHelper: firebaseui.auth.CredentialHelper.NONE,
           signInOptions: [
             firebase.auth.GoogleAuthProvider.PROVIDER_ID,


### PR DESCRIPTION
Add a dependency on the tiny-cookie package and use it to
save and restore the user's locale choice.

Unrelatedly, change a 'Tu Nombre' string to 'Tu nombre' to
match the capitalization used elsewhere in the UI.