### PR TITLE
Use 'v-t' attribute for simple translations.

### DIFF
--- a/src/components/ClimbDropdown.vue
+++ b/src/components/ClimbDropdown.vue
@@ -12,31 +12,25 @@
         width="48px"
         v-on="on"
       >
-        {{ stateAbbrevs[syncedState] }}
+        {{ stateAbbrev }}
       </v-btn>
     </template>
     <v-list class="climb-state-list">
       <v-list-item @click="syncedState = ClimbState.LEAD">
-        <v-list-item-title>{{
-          $t('ClimbDropdown.leadItem')
-        }}</v-list-item-title>
+        <v-list-item-title v-t="'ClimbDropdown.leadItem'" />
       </v-list-item>
       <v-list-item @click="syncedState = ClimbState.TOP_ROPE">
-        <v-list-item-title>{{
-          $t('ClimbDropdown.topRopeItem')
-        }}</v-list-item-title>
+        <v-list-item-title v-t="'ClimbDropdown.topRopeItem'" />
       </v-list-item>
       <v-list-item @click="syncedState = ClimbState.NOT_CLIMBED">
-        <v-list-item-title>{{
-          $t('ClimbDropdown.notClimbedItem')
-        }}</v-list-item-title>
+        <v-list-item-title v-t="'ClimbDropdown.notClimbedItem'" />
       </v-list-item>
     </v-list>
   </v-menu>
 </template>
 
 <script lang="ts">
-import { Component, Prop, PropSync, Vue } from 'vue-property-decorator';
+import { Component, Prop, PropSync, Vue, Watch } from 'vue-property-decorator';
 import { ClimbState } from '@/models';
 
 @Component
@@ -52,12 +46,15 @@ export default class ClimbDropdown extends Vue {
 
   readonly ClimbState = ClimbState;
 
-  get stateAbbrevs() {
-    return {
-      [ClimbState.LEAD]: this.$t('ClimbDropdown.leadAbbrev'),
-      [ClimbState.TOP_ROPE]: this.$t('ClimbDropdown.topRopeAbbrev'),
-      [ClimbState.NOT_CLIMBED]: this.label,
-    };
+  get stateAbbrev(): string {
+    switch (this.syncedState) {
+      case ClimbState.LEAD:
+        return this.$t('ClimbDropdown.leadAbbrev').toString();
+      case ClimbState.TOP_ROPE:
+        return this.$t('ClimbDropdown.topRopeAbbrev').toString();
+      default:
+        return this.label;
+    }
   }
 
   get stateColor() {
@@ -75,6 +72,15 @@ export default class ClimbDropdown extends Vue {
     return this.syncedState == ClimbState.NOT_CLIMBED
       ? 'not-climbed-button'
       : 'white--text';
+  }
+
+  // This seems to be necessary to make the <v-list-item-title> elements update
+  // their translations. I'm not sure why it doesn't seem to be needed for 'v-t'
+  // usage elsewhere. There's some discussion at
+  // https://github.com/kazupon/vue-i18n/issues/227.
+  @Watch('$i18n.locale')
+  onLocaleChange() {
+    this.$forceUpdate();
   }
 }
 </script>

--- a/src/components/LocalePicker.vue
+++ b/src/components/LocalePicker.vue
@@ -50,8 +50,6 @@ export default class LocalePicker extends Vue {
 
   onClick(lc: string) {
     this.$i18n.locale = lc;
-    // I've seen claims online that there should be a this.$forceUpdate() call
-    // here, but it doesn't seem necessary.
   }
 }
 </script>

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -61,15 +61,15 @@
       max-width="320px"
     >
       <DialogCard :title="$t('Toolbar.signOutTitle')">
-        <v-card-text>
-          {{ $t('Toolbar.signOutText') }}
-        </v-card-text>
+        <v-card-text v-t="'Toolbar.signOutText'" />
 
         <v-divider />
         <v-card-actions>
-          <v-btn text @click="signOutDialogShown = false">
-            {{ $t('Toolbar.signOutCancelButton') }}
-          </v-btn>
+          <v-btn
+            text
+            @click="signOutDialogShown = false"
+            v-t="'Toolbar.signOutCancelButton'"
+          />
           <v-spacer />
           <v-btn
             text
@@ -77,9 +77,8 @@
             id="toolbar-sign-out-confirm-button"
             ref="signOutConfirmButton"
             @click="signOut"
-          >
-            {{ $t('Toolbar.signOutConfirmButton') }}
-          </v-btn>
+            v-t="'Toolbar.signOutConfirmButton'"
+          />
         </v-card-actions>
       </DialogCard>
     </v-dialog>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -44,9 +44,10 @@
           />
         </v-form>
 
-        <div class="caption grey--text text--darken-1">
-          {{ $t('Profile.teamMembersLabel') }}
-        </div>
+        <div
+          class="caption grey--text text--darken-1"
+          v-t="'Profile.teamMembersLabel'"
+        />
         <div id="profile-team-members">
           <div v-for="user in teamMembers" :key="user.name" class="member-name">
             {{ user.name }}
@@ -72,9 +73,8 @@
                 :disabled="teamFull"
                 color="primary"
                 v-on="on"
-              >
-                {{ $t('Profile.showInviteCodeButton') }}
-              </v-btn>
+                v-t="'Profile.showInviteCodeButton'"
+              />
             </template>
 
             <DialogCard :title="$t('Profile.inviteCodeTitle')">
@@ -82,9 +82,7 @@
                 <div class="invite-code mb-2">
                   {{ teamDoc.invite }}
                 </div>
-                <div>
-                  {{ $t('Profile.inviteCodeText') }}
-                </div>
+                <div v-t="'Profile.inviteCodeText'" />
               </v-card-text>
 
               <v-divider />
@@ -95,9 +93,8 @@
                   text
                   color="primary"
                   @click="inviteDialogShown = false"
-                >
-                  {{ $t('Profile.dismissButton') }}
-                </v-btn>
+                  v-t="'Profile.dismissButton'"
+                />
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -117,20 +114,20 @@
                 text
                 color="error"
                 v-on="on"
-                >{{ $t('Profile.leaveTeamButton') }}
-              </v-btn>
+                v-t="'Profile.leaveTeamButton'"
+              />
             </template>
 
             <DialogCard title="Leave team">
-              <v-card-text>
-                {{ $t('Profile.leaveTeamText') }}
-              </v-card-text>
+              <v-card-text v-t="'Profile.leaveTeamText'" />
 
               <v-divider />
               <v-card-actions>
-                <v-btn text @click="leaveDialogShown = false">
-                  {{ $t('Profile.cancelButton') }}
-                </v-btn>
+                <v-btn
+                  text
+                  @click="leaveDialogShown = false"
+                  v-t="'Profile.cancelButton'"
+                />
                 <v-spacer />
                 <v-btn
                   id="profile-leave-confirm-button"
@@ -139,9 +136,8 @@
                   color="error"
                   :disabled="leavingTeam"
                   @click="leaveTeam"
-                >
-                  {{ $t('Profile.leaveTeamButton') }}
-                </v-btn>
+                  v-t="'Profile.leaveTeamButton'"
+                />
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -150,9 +146,7 @@
 
       <!-- User is not on a team -->
       <template v-else>
-        <div class="no-team-text mt-2">
-          {{ $t('Profile.notOnTeamText') }}
-        </div>
+        <div class="no-team-text mt-2" v-t="'Profile.notOnTeamText'"/>
 
         <v-divider class="mt-2 mb-4" />
 
@@ -168,9 +162,7 @@
                 id="profile-join-button"
                 ref="joinButton"
                 color="primary"
-                v-on="on"
-                >{{ $t('Profile.joinTeamButton') }}</v-btn
-              >
+                v-on="on" v-t="'Profile.joinTeamButton'" />
             </template>
 
             <DialogCard :title="$t('Profile.joinTeamTitle')">
@@ -207,9 +199,7 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn text @click="joinDialogShown = false">
-                  {{ $t('Profile.cancelButton') }}
-                </v-btn>
+                <v-btn text @click="joinDialogShown = false" v-t="'Profile.cancelButton'"/>
                 <v-spacer />
                 <v-btn
                   id="profile-join-confirm-button"
@@ -217,10 +207,7 @@
                   :disabled="!joinTeamValid || joiningTeam"
                   color="primary"
                   text
-                  @click="joinTeam"
-                >
-                  {{ $t('Profile.joinTeamButton') }}
-                </v-btn>
+                  @click="joinTeam" v-t="'Profile.joinTeamButton'"/>
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -239,16 +226,12 @@
                 id="profile-create-button"
                 ref="createButton"
                 color="primary"
-                v-on="on"
-                >{{ $t('Profile.createTeamButton') }}</v-btn
-              >
+                v-on="on" v-t="'Profile.createTeamButton'"/>
             </template>
 
             <DialogCard :title="$t('Profile.createTeamTitle')">
               <v-card-text>
-                <div>
-                  {{ $t('Profile.createTeamText') }}
-                </div>
+                <div v-t="'Profile.createTeamText'" />
                 <v-form
                   ref="createForm"
                   v-model="createTeamValid"
@@ -271,9 +254,7 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn text @click="createDialogShown = false">
-                  {{ $t('Profile.cancelButton') }}
-                </v-btn>
+                <v-btn text @click="createDialogShown = false" v-t="'Profile.cancelButton'"/>
                 <v-spacer />
                 <v-btn
                   id="profile-create-confirm-button"
@@ -282,9 +263,7 @@
                   color="primary"
                   text
                   @click="createTeam"
-                >
-                  {{ $t('Profile.createTeamButton') }}
-                </v-btn>
+                  v-t="'Profile.createTeamButton'" />
               </v-card-actions>
             </DialogCard>
           </v-dialog>

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -78,18 +78,13 @@
 
         <v-divider />
         <v-card-actions>
-          <v-btn text @click="onCancelFilters">
-            {{ $t('Routes.cancelButton') }}
-          </v-btn>
+          <v-btn text @click="onCancelFilters" v-t="'Routes.cancelButton'" />
           <v-spacer />
           <v-btn
             ref="applyFiltersButton"
             text
             color="primary"
-            @click="onApplyFilters"
-          >
-            {{ $t('Routes.applyButton') }}
-          </v-btn>
+            @click="onApplyFilters" v-t="'Routes.applyButton'" />
         </v-card-actions>
       </DialogCard>
     </v-dialog>

--- a/src/views/RoutesNav.vue
+++ b/src/views/RoutesNav.vue
@@ -11,8 +11,8 @@
       text
       class="white--text"
       @click="$root.$emit('show-route-filters')"
-      >{{ $t('RoutesNav.filtersButton') }}</v-btn
-    >
+      v-t="'RoutesNav.filtersButton'"
+    />
   </v-toolbar-items>
 </template>
 

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -5,10 +5,8 @@
 <template>
   <div v-if="haveStats">
     <v-tabs v-model="tab">
-      <v-tab href="#team" v-if="teamCards.length">{{
-        $t('Statistics.teamTab')
-      }}</v-tab>
-      <v-tab href="#user">{{ $t('Statistics.individualTab') }}</v-tab>
+      <v-tab href="#team" v-if="teamCards.length" v-t="'Statistics.teamTab'" />
+      <v-tab href="#user" v-t="'Statistics.individualTab'" />
 
       <v-tab-item key="team" value="team" v-if="teamCards.length">
         <Card


### PR DESCRIPTION
Use the 'v-t' attribute in elements that just contain
straightforward translated text instead of calling the $t
function via '{{ $t(...) }}'. 'v-t' is allegedly faster:
https://kazupon.github.io/vue-i18n/guide/directive.html#t-vs-v-t