### PR TITLE
Display sync icon in Routes view for pending writes.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,7 @@
 
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Material+Icons"
+      href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons"
     />
   </head>
   <body>

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -53,6 +53,11 @@
       </v-expansion-panel>
     </v-expansion-panels>
 
+    <div class="sync" :class="{ active: pendingWrites }">
+      <v-icon>sync</v-icon>
+      {{ pendingWrites }}
+    </div>
+
     <v-dialog
       ref="filtersDialog"
       v-model="filtersDialogShown"
@@ -200,6 +205,8 @@ export default class Routes extends Mixins(Perf, UserLoader) {
   readonly config: Partial<Config> = {};
   // True after |config| is loaded.
   loadedConfig = false;
+  // Number of pending Firestore writes to update climb states.
+  pendingWrites = 0;
 
   // Minimum and maximum grades of routes in |sortedData|.
   minGrade = Grades[0];
@@ -301,6 +308,11 @@ export default class Routes extends Mixins(Perf, UserLoader) {
         );
         logError('set_climb_state_failed', err);
       });
+
+    this.pendingWrites++;
+    this.firestore.waitForPendingWrites().then(() => {
+      this.pendingWrites--;
+    });
   }
 
   // Returns the number of routes in |routes| that are still available, i.e. not
@@ -549,5 +561,21 @@ export default class Routes extends Mixins(Perf, UserLoader) {
 .count {
   opacity: 0.3;
   text-align: right;
+}
+
+.sync {
+  background-color: rgba(255, 255, 255, 0);
+  bottom: 8px;
+  color: #333;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 12px;
+  transition: 0.4s linear opacity;
+  z-index: 1;
+}
+.sync.active {
+  opacity: 0.5;
+  transition: none;
 }
 </style>


### PR DESCRIPTION
Update the Routes view to display a sync icon and the number
of pending updates in the bottom-right corner of the
viewport when there are climb state changes that haven't
been synced with the backend yet.

Also change the way that we import Material icons in
index.html, since the old non-Roboto import doesn't appear
to contain the 'sync' icon. The existing icons in the
Toolbar view's navigation drawer are still rendered
correctly.