### PR TITLE
Add waitForPendingWrites to mock Firestore implementation.

### DIFF
--- a/src/firebase/mock.ts
+++ b/src/firebase/mock.ts
@@ -311,6 +311,7 @@ jest.mock('firebase/app', () => {
       collection: (path: string) => new MockCollectionReference(path),
       doc: (path: string) => new MockDocumentReference(path),
       enablePersistence: () => Promise.resolve(),
+      waitForPendingWrites: () => Promise.resolve(),
     }),
   };
 


### PR DESCRIPTION
Add a do-nothing mock (actually, stub?) implementation of
the waitForPendingWrites method. Commit 1494565473 made the
Routes view call this, so exceptions started getting thrown
by unit tests. The tests still pass so I didn't notice it.