### PR TITLE
Display build info in nav drawer.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- Make webpack inject build info so we can access it later:
+     https://stackoverflow.com/a/58839441/6882947 -->
+<html
+  lang="en"
+  data-build-time="<%= new Date().toISOString() %>"
+  data-build-commit="<%- VUE_APP_GIT_COMMIT %>"
+>
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -37,6 +37,11 @@
           </v-list-item>
         </template>
       </v-list>
+      <template v-slot:append>
+        <div class="build mb-2 ml-2">
+          {{ $t('Toolbar.buildText', [buildInfo]) }}
+        </div>
+      </template>
     </v-navigation-drawer>
 
     <v-app-bar color="primary" app scroll-off-screen :scroll-threshold="32">
@@ -176,6 +181,12 @@ export default class Toolbar extends Vue {
     return (process.env.VUE_APP_LOCALES || 'en-US,es-PR').split(',');
   }
 
+  get buildInfo(): string {
+    const timestamp = document.documentElement.dataset.buildTime || '';
+    const commit = document.documentElement.dataset.buildCommit || '';
+    return `${timestamp}-${commit.slice(0, 8)}`;
+  }
+
   // Handles the "Sign out" navigation drawer item being clicked.
   onSignOutNav() {
     this.signOutDialogShown = true;
@@ -192,3 +203,11 @@ export default class Toolbar extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.build {
+  color: #aaa;
+  font-size: 11px;
+  padding-left: 2px;
+}
+</style>

--- a/src/locale/en-US.ts
+++ b/src/locale/en-US.ts
@@ -102,6 +102,7 @@ export default {
     totalPointsStat: 'Total points',
   },
   Toolbar: {
+    buildText: 'Build {0}',
     profileItem: 'Profile',
     routesItem: 'Routes',
     signOutCancelButton: 'Cancel',

--- a/src/locale/es-PR.ts
+++ b/src/locale/es-PR.ts
@@ -107,6 +107,7 @@ export default {
     totalPointsStat: 'Puntos totales',
   },
   Toolbar: {
+    buildText: 'Versión {0}',
     profileItem: 'Perfil',
     routesItem: 'Rutas',
     signOutCancelButton: 'Cancelar',

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,13 @@
+// Define a variable containing the git commit:
+// https://stackoverflow.com/a/38401256/6882947
+// https://cli.vuejs.org/guide/mode-and-env.html
+//
+// Note that this does not dynamically update under "npm run serve".
+process.env.VUE_APP_GIT_COMMIT = require('child_process')
+  .execSync('git rev-parse HEAD')
+  .toString()
+  .trim();
+
 module.exports = {
   chainWebpack: config => {
     // html-webpack-plugin performs substitution of environment variables in


### PR DESCRIPTION
Add data attributes to the <html> element at build time that
are later used by the Toolbar component to display the build
timestamp and git commit at the bottom of the navigation
drawer. I think that this will be useful in debugging PWA
caching issues.