### PR TITLE
Shorten long UI strings to fit on small screens.

### DIFF
--- a/src/locale/en-US.ts
+++ b/src/locale/en-US.ts
@@ -62,7 +62,7 @@ export default {
     nameEmptyRule: 'Name must not be empty',
     nameTooLongRule: 'Name must be {0} characters or shorter',
     notOnTeamText: 'You are not on a team.',
-    showInviteCodeButton: 'Show invite code',
+    showInviteCodeButton: 'Invite code', // dropping 'Show' for small screens
     teamFullError: 'Team is full',
     teamMemberLeftLabel: '(left)',
     teamMembersLabel: 'Members',

--- a/src/locale/es-PR.ts
+++ b/src/locale/es-PR.ts
@@ -31,7 +31,7 @@ export default {
     badInviteCodeError: 'Código de invitado incorrecto',
     cancelButton: 'Cancelar',
     cantFindUnusedCodeError: 'No puede encontrar el código no utilizado',
-    createTeamButton: 'Crear equipo',
+    createTeamButton: 'Crear', // dropping 'equipo' for small screens
     createTeamTitle: 'Crear equipo',
     createTeamText:
       'Después de crear un nuevo equipo, recibirá un código de invitado ' +
@@ -55,7 +55,7 @@ export default {
     inviteCodeLengthRule: 'El código debe tener {0} dígitos',
     inviteCodeTitle: 'Código de invitado',
     joinedTeamMessage: '"{0}" unido',
-    joinTeamButton: 'Unirse al equipo',
+    joinTeamButton: 'Unirse', // dropping 'al equipo' for small screens
     joinTeamText:
       'Pídale a su compañero de equipo que le dé el código de invitado ' +
       'de {0} dígitos de su página de perfil.',
@@ -66,7 +66,7 @@ export default {
     nameEmptyRule: 'El nombre no debe estar vacío',
     nameTooLongRule: 'El nombre debe tener {0} caracteres o menos',
     notOnTeamText: 'No estás en un equipo.',
-    showInviteCodeButton: 'Mostrar código de invitado',
+    showInviteCodeButton: 'Invitar', // from 'Mostrar código de invitado'
     teamFullError: 'El equipo está lleno',
     teamMemberLeftLabel: '(salido)',
     teamMembersLabel: 'Miembros',

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -71,6 +71,7 @@
                 id="profile-invite-button"
                 ref="inviteButton"
                 :disabled="teamFull"
+                :small="useSmallButtons"
                 color="primary"
                 v-on="on"
                 v-t="'Profile.showInviteCodeButton'"
@@ -111,6 +112,7 @@
               <v-btn
                 id="profile-leave-button"
                 ref="leaveButton"
+                :small="useSmallButtons"
                 text
                 color="error"
                 v-on="on"
@@ -146,7 +148,7 @@
 
       <!-- User is not on a team -->
       <template v-else>
-        <div class="no-team-text mt-2" v-t="'Profile.notOnTeamText'"/>
+        <div class="no-team-text mt-2" v-t="'Profile.notOnTeamText'" />
 
         <v-divider class="mt-2 mb-4" />
 
@@ -161,14 +163,17 @@
               <v-btn
                 id="profile-join-button"
                 ref="joinButton"
+                :small="useSmallButtons"
                 color="primary"
-                v-on="on" v-t="'Profile.joinTeamButton'" />
+                v-on="on"
+                v-t="'Profile.joinTeamButton'"
+              />
             </template>
 
             <DialogCard :title="$t('Profile.joinTeamTitle')">
               <v-card-text>
                 <div>
-                  {{ $t('Profile.inviteCodeText', [inviteCodeLength]) }}
+                  {{ $t('Profile.joinTeamText', [inviteCodeLength]) }}
                 </div>
                 <v-form
                   ref="joinForm"
@@ -199,7 +204,11 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn text @click="joinDialogShown = false" v-t="'Profile.cancelButton'"/>
+                <v-btn
+                  text
+                  @click="joinDialogShown = false"
+                  v-t="'Profile.cancelButton'"
+                />
                 <v-spacer />
                 <v-btn
                   id="profile-join-confirm-button"
@@ -207,7 +216,9 @@
                   :disabled="!joinTeamValid || joiningTeam"
                   color="primary"
                   text
-                  @click="joinTeam" v-t="'Profile.joinTeamButton'"/>
+                  @click="joinTeam"
+                  v-t="'Profile.joinTeamButton'"
+                />
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -225,8 +236,11 @@
               <v-btn
                 id="profile-create-button"
                 ref="createButton"
+                :small="useSmallButtons"
                 color="primary"
-                v-on="on" v-t="'Profile.createTeamButton'"/>
+                v-on="on"
+                v-t="'Profile.createTeamButton'"
+              />
             </template>
 
             <DialogCard :title="$t('Profile.createTeamTitle')">
@@ -254,7 +268,11 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn text @click="createDialogShown = false" v-t="'Profile.cancelButton'"/>
+                <v-btn
+                  text
+                  @click="createDialogShown = false"
+                  v-t="'Profile.cancelButton'"
+                />
                 <v-spacer />
                 <v-btn
                   id="profile-create-confirm-button"
@@ -263,7 +281,8 @@
                   color="primary"
                   text
                   @click="createTeam"
-                  v-t="'Profile.createTeamButton'" />
+                  v-t="'Profile.createTeamButton'"
+                />
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -383,6 +402,14 @@ export default class Profile extends Mixins(Perf, UserLoader) {
     return userData && userData.climbs
       ? Object.keys(userData.climbs).length
       : 0;
+  }
+
+  // Whether small buttons should be used in the view.
+  get useSmallButtons() {
+    return (
+      !window.matchMedia ||
+      window.matchMedia('screen and (max-width: 400px)').matches
+    );
   }
 
   // Updates the user's name in Firestore when the user name input is changed.


### PR DESCRIPTION
Make various strings in the Profile view shorter so they'll
fit onscreen on iPhone 5/SE, which has a screen width of
just 320 display units. This is particularly a problem in
Spanish.

Also conditionally set the 'small' attribute on the main
buttons in the Profile view for screens with widths up to
400 display units.

Finally, fix an incorrect string in the "Join team" dialog.
It looks like I used the wrong ID here when I finished
translating the Profile view in 3990730e.