### PR TITLE
Use go113 runtime for Cloud Functions.

### DIFF
--- a/ascenso.go
+++ b/ascenso.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"net/http"
 
-	"ascenso/go/admin"
-	"ascenso/go/log"
-	"ascenso/go/test"
+	"github.com/derat/ascenso/go/admin"
+	"github.com/derat/ascenso/go/log"
+	"github.com/derat/ascenso/go/test"
 )
 
 // Admin is the entry point into the "Admin" Cloud Function.

--- a/deploy_cloud_function.sh
+++ b/deploy_cloud_function.sh
@@ -22,4 +22,4 @@ project=$(jq -r .projects.default < ./.firebaserc)
 echo "Deploying $1 to ${project}..."
 
 gcloud --project "${project}" functions deploy "$1" \
-  --runtime go111 --trigger-http
+  --runtime go113 --trigger-http --set-env-vars "GCP_PROJECT=${project}"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ascenso
+module github.com/derat/ascenso
 
 go 1.12
 

--- a/go/admin/admin.go
+++ b/go/admin/admin.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 const maxRequestBytes = 10 << 20 // memory for parsing HTTP requests
@@ -33,7 +33,7 @@ func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 		}
 
 		// Initialize Cloud Firestore.
-		client, err := firestore.NewClient(ctx, os.Getenv("GCP_PROJECT")) // automatically set by runtime
+		client, err := firestore.NewClient(ctx, os.Getenv("GCP_PROJECT")) // set at deployment
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed creating Firestore client: %v", err), http.StatusInternalServerError)
 			return

--- a/go/admin/clear_scores.go
+++ b/go/admin/clear_scores.go
@@ -13,7 +13,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/iterator"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 // handleClearScores handles an "clearScores" POST request.

--- a/go/admin/empty_teams.go
+++ b/go/admin/empty_teams.go
@@ -13,7 +13,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/iterator"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 // handleEmptyTeams handles an "emptyTeams" POST request.

--- a/go/admin/routes.go
+++ b/go/admin/routes.go
@@ -14,7 +14,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 // handlePostRoutes handles a "routes" POST request.

--- a/go/admin/routes_test.go
+++ b/go/admin/routes_test.go
@@ -5,10 +5,11 @@
 package admin
 
 import (
-	"ascenso/go/db"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/derat/ascenso/go/db"
 )
 
 func TestReadAreas(t *testing.T) {

--- a/go/admin/scores.go
+++ b/go/admin/scores.go
@@ -16,7 +16,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/iterator"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 // handlePostScores handles a "scores" POST request.

--- a/go/admin/scores_test.go
+++ b/go/admin/scores_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"testing"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 func TestComputeScore(t *testing.T) {

--- a/go/log/log.go
+++ b/go/log/log.go
@@ -72,7 +72,7 @@ func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 	// will get timestamps 200 ms later than when they actually happened.
 	clientOffset := now.Sub(time.Unix(0, body.Data.Now*int64(time.Millisecond)))
 
-	client, err := logging.NewClient(ctx, os.Getenv("GCP_PROJECT")) // automatically set by runtime
+	client, err := logging.NewClient(ctx, os.Getenv("GCP_PROJECT")) // set at deployment
 	if err != nil {
 		log.Print("Failed creating Stackdriver client: ", err)
 		http.Error(w, "Failed creating logging client", http.StatusInternalServerError)

--- a/go/test/func.go
+++ b/go/test/func.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"ascenso/go/db"
+	"github.com/derat/ascenso/go/db"
 )
 
 // We can't name this file "test.go" since we don't want it to be picked up by "go test".
@@ -75,7 +75,7 @@ func deleteUser(ctx context.Context, email string) error {
 	log.Printf("Deleting user %v with email %v", uid, email)
 
 	// Initialize Cloud Firestore.
-	client, err := firestore.NewClient(ctx, os.Getenv("GCP_PROJECT")) // automatically set by runtime
+	client, err := firestore.NewClient(ctx, os.Getenv("GCP_PROJECT")) // set at deployment
 	if err != nil {
 		return fmt.Errorf("failed creating Firestore client: %v", err)
 	}


### PR DESCRIPTION
Google is deprecating the go111 runtime on 2020-08-05 and
blocking deployments starting 2021-02-15 (since Go 1.11 is
now unspported), so switch to go113.

To make this work, I had to update go.mod and local imports
to use the proper fully-qualified module name (ascenso ->
github.com/derat/ascenso), and I also needed to update
deploy_cloud_function.sh to manually set the GCP_PROJECT
environment variable since it's no longer automatically set
by the runtime.

https://cloud.google.com/functions/docs/concepts/go-runtime
neglects mentioning this, but the change is shown at
https://cloud.google.com/functions/docs/env-var.