### PR TITLE
Sort tied users stably in Admin Cloud Function scoreboard.

### DIFF
--- a/go/admin/scores.go
+++ b/go/admin/scores.go
@@ -140,8 +140,13 @@ func getScores(ctx context.Context, client *firestore.Client) ([]teamSummary, er
 				Height:    height,
 			})
 		}
+
+		// Sort the team's members by descending score and then alphabetically.
 		sort.Slice(summary.Users, func(i, j int) bool {
-			return summary.Users[i].Score > summary.Users[j].Score
+			if si, sj := summary.Users[i].Score, summary.Users[j].Score; si != sj {
+				return si > sj
+			}
+			return summary.Users[i].Name < summary.Users[j].Name
 		})
 
 		teams = append(teams, summary)


### PR DESCRIPTION
Within each team, use users' names as a tiebreaker if their
scores are identical. (This happens a lot, and it made it
hard to tell if people were still entering data when I
refreshed the scoreboard.)