### PR TITLE
Support setting Firestore to readonly mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Heterogeneous singleton documents:
         competition start time.
     *   `endTime` - [firebase.firestore.Timestamp] field containing competition
         end time.
+    *   `readonly` - Boolean field that can be set to true to prevent users from
+        updating data.
 *   `indexedData` - Document containing indexed area and route information:
     *   `areas` - Map field containing area information keyed by area ID, e.g.
         `my_area`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,8 +12,9 @@ rules_version = '2';
 // Basic stuff to keep in mind:
 // - resource.data is a Map containing the doc's data before an update.
 // - request.resource.data is a Map containing the doc's data after an update.
-// - getAfter() returns a Map containing a doc's data after the current
-//   transaction or batched write finishes.
+// - getAfter() returns a rules.firestore.Resource with a 'data' field
+//   containing a map of doc's data after the current transaction or batched
+//   write finishes. get() is similar, but returns the initial data.
 // - Field existence checks take this form:
 //     "key" in request.resource.data
 // - Null checks should only be used when checking non-document data like
@@ -41,6 +42,16 @@ function inviteCodeValid(code) {
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Returns true if the database has been set to readonly mode (via a
+    // 'readonly' boolean field in the /global/config doc). There's no 'deny'
+    // directive in the rules language, so we need to check this all over the
+    // place instead of just rejecting all creates and updates in a single
+    // place.
+    function readonly() {
+      let path = /databases/$(database)/documents/global/config;
+      return exists(path) && get(path).data.get("readonly", false);
+    }
+
     // Let anyone get /global/config.
     match /global/config {
       allow get: if true;
@@ -96,13 +107,13 @@ service cloud.firestore {
 
       // When the user is created, they shouldn't be on a team yet.
       allow create:
-        if loggedIn() && request.auth.uid == uid &&
+        if loggedIn() && request.auth.uid == uid && !readonly() &&
             userDocValid(request.resource.data) &&
             !("team" in request.resource.data);
 
       // For updates, we additionally check the team field.
       allow update:
-        if loggedIn() && request.auth.uid == uid &&
+        if loggedIn() && request.auth.uid == uid && !readonly() &&
             userDocValid(request.resource.data) &&
             checkUserDocTeam(request.resource.data, resource.data);
     }
@@ -128,7 +139,7 @@ service cloud.firestore {
 
       // All logged-in users can create new teams.
       allow create:
-        if loggedIn() &&
+        if loggedIn() && !readonly() &&
             teamDocValid(request.resource.data, request.auth.uid) &&
             // User is only member of new team.
             request.resource.data.users.size() == 1 &&
@@ -139,7 +150,7 @@ service cloud.firestore {
 
       // Users can add themselves to incomplete teams.
       allow update:
-        if loggedIn() &&
+        if loggedIn() && !readonly() &&
             teamDocValid(request.resource.data, request.auth.uid) &&
             // Old team isn't full and doesn't contain user.
             resource.data.users.size() < 2 &&
@@ -156,7 +167,7 @@ service cloud.firestore {
       // Let users update their team docs as long as they don't change the users
       // on the team or its invite code.
       allow update:
-        if loggedIn() &&
+        if loggedIn() && !readonly() &&
             teamDocValid(request.resource.data, request.auth.uid) &&
             request.auth.uid in resource.data.users &&
             request.resource.data.users.keys().hasOnly(resource.data.users.keys()) &&
@@ -165,7 +176,7 @@ service cloud.firestore {
       // Let users remove themselves from their team if they hadn't reported any
       // climbs and don't make any other changes to the doc.
       allow update:
-        if loggedIn() &&
+        if loggedIn() && !readonly() &&
             // Skip teamDocValid() since it expects user to be on team.
             request.auth.uid in resource.data.users &&
             resource.data.users[request.auth.uid].climbs.size() == 0 &&
@@ -181,7 +192,7 @@ service cloud.firestore {
       // Let all logged-in users read or create invites. When creating a doc, it
       // must point at a team that points back at the invite doc.
       allow get: if loggedIn();
-      allow create: if loggedIn() &&
+      allow create: if loggedIn() && !readonly() &&
         inviteCodeValid(invite) &&
         "team" in request.resource.data &&
         getAfter(/databases/$(database)/documents/teams/$(request.resource.data.team)).data.invite == invite;

--- a/go/admin/admin.go
+++ b/go/admin/admin.go
@@ -54,6 +54,8 @@ func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 			handleClearScores(ctx, w, r, client)
 		case "emptyTeams":
 			handleEmptyTeams(ctx, w, r, client)
+		case "readonly":
+			handleReadonly(ctx, w, r, client)
 		case "routes":
 			handlePostRoutes(ctx, w, r, client)
 		case "scores":
@@ -62,6 +64,8 @@ func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 			handlePostScoresTeamsCSV(ctx, w, r, client)
 		case "scoresUsersCsv":
 			handlePostScoresUsersCSV(ctx, w, r, client)
+		case "writable":
+			handleWritable(ctx, w, r, client)
 		default:
 			http.Error(w, fmt.Sprintf("Bad action %q", action), http.StatusBadRequest)
 		}
@@ -142,6 +146,13 @@ const getHTML = `
         <button name="action" value="routes" type="submit">
           Update routes
         </button>
+      </div>
+
+      <h2>Lock or unlock database</h2>
+      <p>Set database to be read-only or writable.</p>
+      <div class="input-row">
+        <button name="action" value="readonly" type="submit">Read-only</button>
+        <button name="action" value="writable" type="submit">Writable</button>
       </div>
 
       <h2>Delete empty teams</h2>

--- a/go/admin/readonly.go
+++ b/go/admin/readonly.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Daniel Erat and Niniane Wang. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"cloud.google.com/go/firestore"
+	"github.com/derat/ascenso/go/db"
+)
+
+// handleReadonly handles a "readonly" POST request.
+// It updates the config so that the Firestore database cannot be modified by users.
+func handleReadonly(ctx context.Context, w http.ResponseWriter, r *http.Request, client *firestore.Client) {
+	setReadonly(ctx, w, client, true)
+}
+
+// handleReadonly handles a "writable" POST request.
+// It updates the config so that the Firestore database is writable by users.
+func handleWritable(ctx context.Context, w http.ResponseWriter, r *http.Request, client *firestore.Client) {
+	setReadonly(ctx, w, client, false)
+}
+
+// setReadonly updates the global config doc's 'readonly' field.
+func setReadonly(ctx context.Context, w http.ResponseWriter, client *firestore.Client, readonly bool) {
+	if _, err := client.Doc(db.ConfigDocPath).Set(ctx, map[string]interface{}{
+		"readonly": readonly,
+	}, firestore.MergeAll); err != nil {
+		http.Error(w, fmt.Sprintf("Failed setting readonly state: %v", err), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintf(w, "Set database readonly state to %v", readonly)
+}

--- a/go/db/firestore.go
+++ b/go/db/firestore.go
@@ -15,6 +15,7 @@ import (
 const (
 	// Document paths in Cloud Firestore.
 	AuthDocPath        = "global/auth"
+	ConfigDocPath      = "global/config"
 	IndexedDataDocPath = "global/indexedData"
 	SortedDataDocPath  = "global/sortedData"
 

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -379,7 +379,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
     // Sort by UID to get stable ordering.
     return Object.keys(this.teamDoc.users)
       .sort()
-      .map(uid => {
+      .map((uid) => {
         // Required by TypeScript.
         if (!this.teamDoc.users) return { name: '', climbs: {} };
         return this.teamDoc.users[uid];
@@ -421,7 +421,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
       return;
     }
 
-    new Promise(resolve => {
+    new Promise((resolve) => {
       logInfo('set_user_name', { name: name });
       if (!this.userRef) throw new Error('No ref to user doc');
       const batch = this.firestore.batch();
@@ -431,7 +431,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
         batch.update(this.teamRef, { [key]: name });
       }
       resolve(batch.commit());
-    }).catch(err => {
+    }).catch((err) => {
       this.$emit(
         'error-msg',
         this.$t('Profile.failedSettingUserNameError', [err.message])
@@ -449,11 +449,11 @@ export default class Profile extends Mixins(Perf, UserLoader) {
       return;
     }
 
-    new Promise(resolve => {
+    new Promise((resolve) => {
       logInfo('set_team_name', { team: this.userDoc.team, name: name });
       if (!this.teamRef) throw new Error('No ref to team doc');
       resolve(this.teamRef.update({ name: name }));
-    }).catch(err => {
+    }).catch((err) => {
       this.$emit(
         'error-msg',
         this.$t('Profile.failedSettingTeamNameError', [err.message])
@@ -513,7 +513,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
         );
         this.createTeamName = '';
       })
-      .catch(err => {
+      .catch((err) => {
         this.$emit(
           'error-msg',
           this.$t('Profile.failedCreatingTeamError', [err.message])
@@ -548,7 +548,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
       .collection('invites')
       .doc(this.joinInviteCode)
       .get()
-      .then(inviteSnap => {
+      .then((inviteSnap) => {
         // Now get the team doc.
         const data = inviteSnap.data();
         if (!data) {
@@ -559,7 +559,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
         teamRef = this.firestore.collection('teams').doc(data.team);
         return teamRef.get();
       })
-      .then(teamSnap => {
+      .then((teamSnap) => {
         // These checks are required by TypeScript.
         if (!this.userRef) throw new Error('No ref to user doc');
         if (!teamRef) throw new Error('No ref to team doc');
@@ -599,7 +599,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
           this.$t('Profile.joinedTeamMessage', [teamName])
         );
       })
-      .catch(err => {
+      .catch((err) => {
         this.$emit(
           'error-msg',
           this.$t('Profile.failedJoiningTeamError', [err.message])
@@ -622,7 +622,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
     // Grab this before leaving so we can use it in a message later.
     const teamName = this.teamDoc.name;
 
-    new Promise(resolve => {
+    new Promise((resolve) => {
       if (!this.userRef) throw new Error('No user ref');
       if (!this.teamRef) throw new Error('No team ref');
 
@@ -655,10 +655,10 @@ export default class Profile extends Mixins(Perf, UserLoader) {
         );
         this.leaveDialogShown = false;
       })
-      .catch(err => {
+      .catch((err) => {
         this.$emit(
           'error-msg',
-          this.$t('Profile.failedLeavingTeam', [err.message])
+          this.$t('Profile.failedLeavingTeamError', [err.message])
         );
         logError('leave_team_failed', err);
       })
@@ -680,7 +680,7 @@ export default class Profile extends Mixins(Perf, UserLoader) {
       .collection('invites')
       .doc(code)
       .get()
-      .then(snap => {
+      .then((snap) => {
         if (!snap.exists) return code;
         if (remainingTries == 0) {
           throw new Error(this.$t('Profile.cantFindUnusedCodeError'));


### PR DESCRIPTION
Update the Firestore security rules to check a 'readonly'
boolean field in the global/config document before letting
users create or update documents, and update the Admin Cloud
Function to support updating the state of this field. The
intent is to make it possible to disallow any further
changes once the competition is over and users have finished
entering their climbs.

If the user tries to make a change while in readonly mode,
an error is shown onscreen and the change is reverted. I'm
also fixing an incorrect reference to a translated error
string that I just noticed. (Prettier's default behavior has
been updated, so this also reformats some code in
Profile.vue.)

It's probably due to something in my local setup (maybe not
having the 'firebase' command installed globally?), but I
noticed that 'npm run test:unit:only firestore' seems to
just hang indefinitely now. The Firestore rules tests seem
to still work on Travis, though, and they also pass locally
when I run the Firestore emulator explicitly:

npx firebase emulators:exec --only firestore \
  "vue-cli-service test:unit --testPathPattern ./firestore.test.ts"