### PR TITLE
Add tooltips listing climbs to scoreboards.

### DIFF
--- a/go/admin/scores_test.go
+++ b/go/admin/scores_test.go
@@ -51,12 +51,12 @@ func TestWriteScores(t *testing.T) {
 	var b bytes.Buffer
 	if err := writeScores(&b, []teamSummary{
 		{"Team A", 123, 10, 800, []userSummary{
-			{"User 1", "Team A", 100, 8, 500},
-			{"User 2", "Team A", 23, 2, 300},
+			{"User 1", "Team A", 100, 8, 500, ""},
+			{"User 2", "Team A", 23, 2, 300, ""},
 		}},
 		{"Team B", 45, 5, 600, []userSummary{
-			{"User 3", "Team B", 25, 3, 400},
-			{"User 4", "Team B", 20, 2, 200},
+			{"User 3", "Team B", 25, 3, 400, ""},
+			{"User 4", "Team B", 20, 2, 200, ""},
 		}},
 	}, nil); err != nil {
 		t.Fatal("writeScores failed: ", err)


### PR DESCRIPTION
Add title attributes to the Admin Cloud Function's
scoreboards that list each user's climbs. This is helpful
when comparing the submitted scores against paper scorecards
at the end of the competition.