### PR TITLE
Support deleting teams from Admin Cloud Function.

### DIFF
--- a/go/admin/admin.go
+++ b/go/admin/admin.go
@@ -169,6 +169,10 @@ const getHTML = `
       <h2>Clear scores</h2>
       <p>Clear scores for all teams and users.</p>
       <div class="input-row">
+        <input id="deleteTeams" name="deleteTeams" value="1" type="checkbox">
+        <label for="deleteTeams">Also delete all teams</label>
+      </div>
+      <div class="input-row">
         <span class="label">Confirm</span>
         <input
           name="confirm"

--- a/src/firebase/mock.ts
+++ b/src/firebase/mock.ts
@@ -267,6 +267,7 @@ export const MockFirebase = new (class {
       // Assign the data to the Vue.
       const data = deepCopy(MockFirebase._docs[ref.path]);
       (this as Vue).$data[name] = data;
+      (this as Vue).$firestoreRefs[name] = data;
       return Promise.resolve(data);
     },
 
@@ -279,7 +280,10 @@ export const MockFirebase = new (class {
         );
       }
       vm.$data[name] = null;
+      delete vm.$firestoreRefs[name];
     },
+
+    $firestoreRefs: {} as Record<String, any>,
   };
 })();
 

--- a/src/mixins/UserLoader.ts
+++ b/src/mixins/UserLoader.ts
@@ -73,7 +73,7 @@ export default class UserLoader extends Vue {
           this.userLoadError = err;
         });
     } else {
-      this.$unbind('teamDoc');
+      if (this.$firestoreRefs.teamDoc) this.$unbind('teamDoc');
       this.teamDoc = {};
       this.teamRef = null;
     }

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -8,6 +8,7 @@
       <v-tab href="#team" v-if="teamCards.length" v-t="'Statistics.teamTab'" />
       <v-tab href="#user" v-t="'Statistics.individualTab'" />
       <v-tab
+        v-if="teamDoc"
         href="#image"
         v-t="'Statistics.imageTab'"
         @change="onImageTabClick"
@@ -37,7 +38,7 @@
         </Card>
       </v-tab-item>
 
-      <v-tab-item key="image" value="image">
+      <v-tab-item v-if="teamDoc" key="image" value="image">
         <Card class="mt-3 mx-0">
           <img class="stats-img" :src="imageData" />
         </Card>


### PR DESCRIPTION
Add a checkbox that can be used to also delete all teams
while clearing scores.

Also update the Statistics view to avoid showing the image
tab if the user isn't on a team.