### PR TITLE
Remove (almost) all uses of the v-t attribute.

### DIFF
--- a/src/components/ClimbDropdown.vue
+++ b/src/components/ClimbDropdown.vue
@@ -17,6 +17,14 @@
     </template>
     <v-list class="climb-state-list">
       <v-list-item @click="syncedState = ClimbState.LEAD">
+        <!-- In general, v-t (vue-i18n's version of Vue's v-text) seems like a
+             bad choice: it sets the element's textContent property, so it
+             overwrites any existing content. The Vuetify guidance is to avoid
+             using it on components:
+             https://github.com/vuetifyjs/vuetify/issues/11792
+             I'm keeping it here since it's apparently more performant than
+             $t() and we create a zillion of these components:
+             https://kazupon.github.io/vue-i18n/guide/directive.html#t-vs-v-t -->
         <v-list-item-title v-t="'ClimbDropdown.leadItem'" />
       </v-list-item>
       <v-list-item @click="syncedState = ClimbState.TOP_ROPE">

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -66,15 +66,13 @@
       max-width="320px"
     >
       <DialogCard :title="$t('Toolbar.signOutTitle')">
-        <v-card-text v-t="'Toolbar.signOutText'" />
+        <v-card-text>{{ $t('Toolbar.signOutText') }}</v-card-text>
 
         <v-divider />
         <v-card-actions>
-          <v-btn
-            text
-            @click="signOutDialogShown = false"
-            v-t="'Toolbar.signOutCancelButton'"
-          />
+          <v-btn text @click="signOutDialogShown = false">
+            {{ $t('Toolbar.signOutCancelButton') }}
+          </v-btn>
           <v-spacer />
           <v-btn
             text
@@ -82,8 +80,9 @@
             id="toolbar-sign-out-confirm-button"
             ref="signOutConfirmButton"
             @click="signOut"
-            v-t="'Toolbar.signOutConfirmButton'"
-          />
+          >
+            {{ $t('Toolbar.signOutConfirmButton') }}
+          </v-btn>
         </v-card-actions>
       </DialogCard>
     </v-dialog>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -44,16 +44,15 @@
           />
         </v-form>
 
-        <div
-          class="caption grey--text text--darken-1"
-          v-t="'Profile.teamMembersLabel'"
-        />
+        <div class="caption grey--text text--darken-1">
+          {{ $t('Profile.teamMembersLabel') }}
+        </div>
         <div id="profile-team-members">
           <div v-for="user in teamMembers" :key="user.name" class="member-name">
             {{ user.name }}
-            <span v-if="user.left">{{
-              $t('Profile.teamMemberLeftLabel')
-            }}</span>
+            <span v-if="user.left">
+              {{ $t('Profile.teamMemberLeftLabel') }}
+            </span>
           </div>
         </div>
 
@@ -74,8 +73,9 @@
                 :small="useSmallButtons"
                 color="primary"
                 v-on="on"
-                v-t="'Profile.showInviteCodeButton'"
-              />
+              >
+                {{ $t('Profile.showInviteCodeButton') }}
+              </v-btn>
             </template>
 
             <DialogCard :title="$t('Profile.inviteCodeTitle')">
@@ -83,7 +83,7 @@
                 <div class="invite-code mb-2">
                   {{ teamDoc.invite }}
                 </div>
-                <div v-t="'Profile.inviteCodeText'" />
+                <div>{{ $t('Profile.inviteCodeText') }}</div>
               </v-card-text>
 
               <v-divider />
@@ -94,8 +94,9 @@
                   text
                   color="primary"
                   @click="inviteDialogShown = false"
-                  v-t="'Profile.dismissButton'"
-                />
+                >
+                  {{ $t('Profile.dismissButton') }}
+                </v-btn>
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -116,20 +117,19 @@
                 text
                 color="error"
                 v-on="on"
-                v-t="'Profile.leaveTeamButton'"
-              />
+              >
+                {{ $t('Profile.leaveTeamButton') }}
+              </v-btn>
             </template>
 
             <DialogCard title="Leave team">
-              <v-card-text v-t="'Profile.leaveTeamText'" />
+              <v-card-text>{{ $t('Profile.leaveTeamText') }}</v-card-text>
 
               <v-divider />
               <v-card-actions>
-                <v-btn
-                  text
-                  @click="leaveDialogShown = false"
-                  v-t="'Profile.cancelButton'"
-                />
+                <v-btn text @click="leaveDialogShown = false">
+                  {{ $t('Profile.cancelButton') }}
+                </v-btn>
                 <v-spacer />
                 <v-btn
                   id="profile-leave-confirm-button"
@@ -138,8 +138,9 @@
                   color="error"
                   :disabled="leavingTeam"
                   @click="leaveTeam"
-                  v-t="'Profile.leaveTeamButton'"
-                />
+                >
+                  {{ $t('Profile.leaveTeamButton') }}
+                </v-btn>
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -148,7 +149,7 @@
 
       <!-- User is not on a team -->
       <template v-else>
-        <div class="no-team-text mt-2" v-t="'Profile.notOnTeamText'" />
+        <div class="no-team-text mt-2">{{ $t('Profile.notOnTeamText') }}</div>
 
         <v-divider class="mt-2 mb-4" />
 
@@ -166,8 +167,9 @@
                 :small="useSmallButtons"
                 color="primary"
                 v-on="on"
-                v-t="'Profile.joinTeamButton'"
-              />
+              >
+                {{ $t('Profile.joinTeamButton') }}
+              </v-btn>
             </template>
 
             <DialogCard :title="$t('Profile.joinTeamTitle')">
@@ -204,11 +206,9 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn
-                  text
-                  @click="joinDialogShown = false"
-                  v-t="'Profile.cancelButton'"
-                />
+                <v-btn text @click="joinDialogShown = false">
+                  {{ $t('Profile.cancelButton') }}
+                </v-btn>
                 <v-spacer />
                 <v-btn
                   id="profile-join-confirm-button"
@@ -217,8 +217,9 @@
                   color="primary"
                   text
                   @click="joinTeam"
-                  v-t="'Profile.joinTeamButton'"
-                />
+                >
+                  {{ $t('Profile.joinTeamButton') }}
+                </v-btn>
               </v-card-actions>
             </DialogCard>
           </v-dialog>
@@ -239,13 +240,14 @@
                 :small="useSmallButtons"
                 color="primary"
                 v-on="on"
-                v-t="'Profile.createTeamButton'"
-              />
+              >
+                {{ $t('Profile.createTeamButton') }}
+              </v-btn>
             </template>
 
             <DialogCard :title="$t('Profile.createTeamTitle')">
               <v-card-text>
-                <div v-t="'Profile.createTeamText'" />
+                <div>{{ $t('Profile.createTeamText') }}</div>
                 <v-form
                   ref="createForm"
                   v-model="createTeamValid"
@@ -268,11 +270,9 @@
 
               <v-divider />
               <v-card-actions>
-                <v-btn
-                  text
-                  @click="createDialogShown = false"
-                  v-t="'Profile.cancelButton'"
-                />
+                <v-btn text @click="createDialogShown = false">
+                  {{ $t('Profile.cancelButton') }}
+                </v-btn>
                 <v-spacer />
                 <v-btn
                   id="profile-create-confirm-button"
@@ -281,8 +281,9 @@
                   color="primary"
                   text
                   @click="createTeam"
-                  v-t="'Profile.createTeamButton'"
-                />
+                >
+                  {{ $t('Profile.createTeamButton') }}
+                </v-btn>
               </v-card-actions>
             </DialogCard>
           </v-dialog>

--- a/src/views/Routes.vue
+++ b/src/views/Routes.vue
@@ -75,14 +75,12 @@
       max-width="512px"
     >
       <DialogCard :title="$t('Routes.routeFiltersTitle')">
-        <v-subheader ref="filtersGradeLabel">
-          {{
-            $t('Routes.gradeRangeLabel', [
-              filtersDialogGrades[0],
-              filtersDialogGrades[1],
-            ])
-          }}
-        </v-subheader>
+        <v-subheader ref="filtersGradeLabel">{{
+          $t('Routes.gradeRangeLabel', [
+            filtersDialogGrades[0],
+            filtersDialogGrades[1],
+          ])
+        }}</v-subheader>
         <v-card-text>
           <GradeSlider
             ref="filtersGradeSlider"
@@ -96,15 +94,18 @@
 
         <v-divider />
         <v-card-actions>
-          <v-btn text @click="onCancelFilters" v-t="'Routes.cancelButton'" />
+          <v-btn text @click="onCancelFilters">
+            {{ $t('Routes.cancelButton') }}
+          </v-btn>
           <v-spacer />
           <v-btn
             ref="applyFiltersButton"
             text
             color="primary"
             @click="onApplyFilters"
-            v-t="'Routes.applyButton'"
-          />
+          >
+            {{ $t('Routes.applyButton') }}
+          </v-btn>
         </v-card-actions>
       </DialogCard>
     </v-dialog>

--- a/src/views/RoutesNav.vue
+++ b/src/views/RoutesNav.vue
@@ -7,12 +7,9 @@
     <!-- Emit an event on the root Vue instance that the Routes view can listen
          for. See https://stackoverflow.com/a/47004242 for more about this
          approach. -->
-    <v-btn
-      text
-      class="white--text"
-      @click="$root.$emit('show-route-filters')"
-      v-t="'RoutesNav.filtersButton'"
-    />
+    <v-btn text class="white--text" @click="$root.$emit('show-route-filters')">
+      {{ $t('RoutesNav.filtersButton') }}
+    </v-btn>
   </v-toolbar-items>
 </template>
 

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -5,14 +5,17 @@
 <template>
   <div v-if="haveStats">
     <v-tabs v-model="tab">
-      <v-tab href="#team" v-if="teamCards.length" v-t="'Statistics.teamTab'" />
-      <v-tab href="#user" v-t="'Statistics.individualTab'" />
+      <v-tab href="#team" v-if="teamCards.length">
+        {{ $t('Statistics.teamTab') }}
+      </v-tab>
+      <v-tab href="#user">{{ $t('Statistics.individualTab') }}</v-tab>
       <v-tab
         v-if="teamDoc && teamDoc.users"
         href="#image"
-        v-t="'Statistics.imageTab'"
         @change="onImageTabClick"
-      />
+      >
+        {{ $t('Statistics.imageTab') }}
+      </v-tab>
 
       <v-tab-item key="team" value="team" v-if="teamCards.length">
         <Card


### PR DESCRIPTION
The v-t attribute, vue-i18n's version of v-text, apparently
replaces the contents of the element that it's used on, so
it shouldn't be set on components. Otherwise, we get errors
like the following when the 'Leave team' dialog is closed:

  Uncaught DOMException: Failed to execute 'removeChild' on
  'Node': The node to be removed is not a child of this
  node.

I'm still keeping a few uses of v-t in the ClimbDropdown
component, since it's allegedly more performant than $t()
and I haven't noticed any problems there.