### PR TITLE
Upgrade to Vuetify 2.6.4 (from 2.2.18).

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -18,6 +18,7 @@ module.exports = {
   webdriver: {
     start_process: true,
     server_path: 'node_modules/.bin/chromedriver',
+    //server_path: '/usr/local/bin/chromedriver',
     port: 9515,
     verbose: true,
     // chromedriver.log is created within this directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "vue-router": "^3.0.7",
         "vue-the-mask": "^0.11.1",
         "vuefire": "^2.2.5",
-        "vuetify": "^2.2.18"
+        "vuetify": "^2.6.4"
       },
       "devDependencies": {
         "@firebase/rules-unit-testing": "^1.3.15",
@@ -56,7 +56,7 @@
         "jest": "^24.9.0",
         "nightwatch": "^1.7.12",
         "release-it": "^13.6.1",
-        "sass": "^1.22.12",
+        "sass": "^1.25.0",
         "sass-loader": "^8.0.2",
         "start-server-and-test": "^1.10.0",
         "stylus": "^0.54.5",
@@ -13711,34 +13711,26 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -13746,17 +13738,13 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13764,75 +13752,57 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -13842,27 +13812,21 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -13876,10 +13840,8 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13897,17 +13859,13 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -13917,20 +13875,16 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -13938,27 +13892,21 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -13968,17 +13916,13 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13988,17 +13932,13 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -14006,10 +13946,8 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -14017,10 +13955,8 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -14030,17 +13966,13 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -14055,10 +13987,8 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -14077,10 +14007,8 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -14091,27 +14019,21 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -14120,10 +14042,8 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -14133,60 +14053,48 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -14194,27 +14102,21 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -14227,10 +14129,8 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14243,10 +14143,8 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -14256,65 +14154,49 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -14326,10 +14208,8 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -14339,20 +14219,16 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -14368,34 +14244,26 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fstream": {
       "version": "1.0.12",
@@ -25358,9 +25226,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.12.tgz",
-      "integrity": "sha512-u5Rxn+dKTPCW5/11kMNxtmqKsxCjcpnqj9CaJoru1NqeJ0DOa9rOM00e0HqmseTAatGkKoLY+jaNecMYevu1gg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.25.0.tgz",
+      "integrity": "sha512-uQMjye0Y70SEDGO56n0j91tauqS9E1BmpKHtiYNQScXDHeaE9uHwNEqQNFf4Bes/3DHMNinB6u79JsG10XWNyw==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -29107,9 +28975,16 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.18.tgz",
-      "integrity": "sha512-RXN065xh5xKmTnEH6+1YFZWp67soOJPTIqqPNliSp9eE72Q7a5fmaV1xQsEVVaVA12+5Hvroo7NW7MP/APucGw=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.4.tgz",
+      "integrity": "sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.4"
+      }
     },
     "node_modules/vuetify-loader": {
       "version": "1.4.3",
@@ -41593,27 +41468,19 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -41621,15 +41488,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -41637,81 +41500,57 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -41726,8 +41565,6 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -41739,15 +41576,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -41755,8 +41588,6 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -41764,8 +41595,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -41773,51 +41602,37 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -41826,8 +41641,6 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -41835,23 +41648,17 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -41861,8 +41668,6 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -41879,8 +41684,6 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -41889,23 +41692,17 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -41915,8 +41712,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -41926,42 +41721,30 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -41969,21 +41752,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -41994,8 +41771,6 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -42009,53 +41784,37 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -42063,8 +41822,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -42074,23 +41831,17 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -42103,30 +41854,22 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -51119,9 +50862,9 @@
       }
     },
     "sass": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.12.tgz",
-      "integrity": "sha512-u5Rxn+dKTPCW5/11kMNxtmqKsxCjcpnqj9CaJoru1NqeJ0DOa9rOM00e0HqmseTAatGkKoLY+jaNecMYevu1gg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.25.0.tgz",
+      "integrity": "sha512-uQMjye0Y70SEDGO56n0j91tauqS9E1BmpKHtiYNQScXDHeaE9uHwNEqQNFf4Bes/3DHMNinB6u79JsG10XWNyw==",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -54233,9 +53976,10 @@
       }
     },
     "vuetify": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.18.tgz",
-      "integrity": "sha512-RXN065xh5xKmTnEH6+1YFZWp67soOJPTIqqPNliSp9eE72Q7a5fmaV1xQsEVVaVA12+5Hvroo7NW7MP/APucGw=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.4.tgz",
+      "integrity": "sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w==",
+      "requires": {}
     },
     "vuetify-loader": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vue-router": "^3.0.7",
     "vue-the-mask": "^0.11.1",
     "vuefire": "^2.2.5",
-    "vuetify": "^2.2.18"
+    "vuetify": "^2.6.4"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.3.15",
@@ -63,7 +63,7 @@
     "jest": "^24.9.0",
     "nightwatch": "^1.7.12",
     "release-it": "^13.6.1",
-    "sass": "^1.22.12",
+    "sass": "^1.25.0",
     "sass-loader": "^8.0.2",
     "start-server-and-test": "^1.10.0",
     "stylus": "^0.54.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@
     <Toolbar v-if="showToolbar" :title="$t(`App.${$route.name}Title`)">
       <router-view name="nav" />
     </Toolbar>
-    <v-content>
+    <v-main>
       <!-- Ideally, this could be wrapped in <keep-alive include="Routes"> to
            keep the slow-to-render Routes view alive after navigating away from
            it, but that seems to break vuefire bindings: after switching away
@@ -21,18 +21,16 @@
         @info-msg="onMessage($event, 'info', 3000)"
       />
 
-      <!-- TODO: Change timeout to -1 for Vuetify 2.3+. -->
-      <v-snackbar v-model="showingUpdate" bottom color="success" :timeout="0">
+      <v-snackbar v-model="showingUpdate" bottom color="success" :timeout="-1">
         {{ $t('App.updateAvailableText') }}
-        <!-- TODO: This v-btn and v-icon may need to be wrapped in a template so
-             they can have v-bind="attrs" after upgrading Vuetify and/or Vue.
-             With the current version, doing so makes them not show up. :-/ -->
-        <v-btn text @click="onUpdateReloadClick">
-          {{ $t('App.updateReloadButton') }}
-        </v-btn>
-        <v-icon small @click="onUpdateDismissClick" color="white" class="mx-2"
-          >close</v-icon
-        >
+        <template v-slot:action>
+          <v-btn text @click="onUpdateReloadClick">
+            {{ $t('App.updateReloadButton') }}
+          </v-btn>
+          <v-icon small @click="onUpdateDismissClick" color="white" class="mx-2"
+            >close</v-icon
+          >
+        </template>
       </v-snackbar>
 
       <!-- This component is used to display transient messages. -->
@@ -48,9 +46,13 @@
              https://stackoverflow.com/q/49627750 both suggest the hack of
              setting 'persistent' on the dialog to prevent clicks outside of it
              from closing it, but that's not very user-friendly. -->
-        <v-btn text @click="showSnackbar = false">Close</v-btn>
+        <template v-slot:action>
+          <v-icon small @click="showSnackbar = false" color="white" class="mx-2"
+            >close</v-icon
+          >
+        </template>
       </v-snackbar>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 
@@ -80,7 +82,7 @@ export default class App extends Mixins(Perf) {
   // automatically sets this to false once the timeout has been reached.
   showSnackbar = false;
   // Amount of time to display snackbar before autohiding, in milliseconds.
-  snackbarTimeoutMs = 0;
+  snackbarTimeoutMs = -1;
 
   get showToolbar() {
     return this.signedIn && this.$route.meta && this.$route.meta.auth;

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -4,7 +4,7 @@
 
 <template>
   <v-row justify="center">
-    <v-col cols="12" sm="8" md="6" class="py-0">
+    <v-col cols="12" sm="8" md="6">
       <v-card class="pa-4">
         <div class="caption" v-if="title">{{ title }}</div>
         <slot></slot>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -27,7 +27,7 @@
       </v-form>
     </Card>
 
-    <Card :title="$t('Profile.teamTitle')" class="py-3">
+    <Card :title="$t('Profile.teamTitle')" class="mt-0">
       <v-spacer class="mt-3" />
 
       <!-- User is on a team -->

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -17,32 +17,45 @@
         {{ $t('Statistics.imageTab') }}
       </v-tab>
 
-      <v-tab-item key="team" value="team" v-if="teamCards.length">
+      <v-tab-item key="team" value="team" v-if="teamCards.length" class="mt-3">
         <Card
           v-for="(card, i) in teamCards"
           :key="card.name"
           :title="card.name"
-          class="mt-3 mx-0"
-          :class="'team-card-' + i"
+          class="mx-0"
+          :class="{
+            ['team-card-' + i]: true,
+            ['mb-n6']: i < teamCards.length - 1,
+            ['mb-1']: i === teamCards.length - 1,
+          }"
         >
           <StatisticsList :items="card.items" />
         </Card>
       </v-tab-item>
 
-      <v-tab-item key="user" value="user">
+      <v-tab-item key="user" value="user" class="mt-3">
         <Card
           v-for="(card, i) in userCards"
           :key="card.name"
           :title="card.name"
-          class="mt-3 mx-0"
-          :class="'user-card-' + i"
+          class="mx-0"
+          :class="{
+            ['user-card-' + i]: true,
+            ['mb-n6']: i < userCards.length - 1,
+            ['mb-1']: i === userCards.length - 1,
+          }"
         >
           <StatisticsList :items="card.items" />
         </Card>
       </v-tab-item>
 
-      <v-tab-item v-if="teamDoc && teamDoc.users" key="image" value="image">
-        <Card class="mt-3 mx-0">
+      <v-tab-item
+        v-if="teamDoc && teamDoc.users"
+        key="image"
+        value="image"
+        class="mt-3"
+      >
+        <Card class="mx-0">
           <img class="stats-img" :src="imageData" />
         </Card>
       </v-tab-item>


### PR DESCRIPTION
Run 'npm install vuetify@latest' to install vuetify@2.6.4.

That resulted in "SassError: @use is coming soon, but it's
not supported in this version of Dart Sass." when running
'npm run serve', so I also ran 'npm install sass@latest' to
upgrade to sass@1.49.9 (from 1.22.12).

That resulted in a zillion deprecation warnings about
Vuetify using deprecated things in Sass, so then I ran 'npm
install sass@1.25.0' to downgrade to the version that
allegedly introduced @use, which seems to work.

I also had to make some minor tweaks in response to padding
and margin changes in Vuetify.